### PR TITLE
Improved output capturing and added tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,9 @@ The following line magics are supported:
  - `%use <lib1>, <lib2> ...` - injects code for supported libraries: artifact resolution, default imports, initialization code, type renderers
  - `%trackClasspath` - logs any changes of current classpath. Useful for debugging artifact resolution failures
  - `%trackExecution` - logs pieces of code that are going to be executed. Useful for debugging of libraries support
- - `%output [--max-cell-size=N] [--max-buffer=N] [--max-buffer-newline=N] [--max-time=N] [--no-stdout] [--reset-to-defaults]` - 
- output capturing settings.
-     - `max-cell-size` specifies the characters count which may be printed to stdout. Default is 100000.
-     - `max-buffer` - max characters count stored in internal buffer before being sent to client. Default is 10000.
-     - `max-buffer-newline` - same as above, but trigger happens only if newline character was encountered. Default is 100.
-     - `max-time` - max time in milliseconds before the buffer is sent to client. Default is 100.
-     - `no-stdout` - don't capture output. Default is false.
-     - `reset-to-defaults` - reset all output settings that were set with magics to defaults
+ - `%output [options]` - output capturing settings.
+ 
+ See detailed info about line magics [here](doc/magics.md).
  
 ### Supported Libraries
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ The following line magics are supported:
  - `%use <lib1>, <lib2> ...` - injects code for supported libraries: artifact resolution, default imports, initialization code, type renderers
  - `%trackClasspath` - logs any changes of current classpath. Useful for debugging artifact resolution failures
  - `%trackExecution` - logs pieces of code that are going to be executed. Useful for debugging of libraries support
+ - `%output [--max-cell-size=N] [--max-buffer=N] [--max-buffer-newline=N] [--max-time=N] [--no-stdout] [--reset-to-defaults]` - 
+ output capturing settings.
+     - `max-cell-size` specifies the characters count which may be printed to stdout. Default is 100000.
+     - `max-buffer` - max characters count stored in internal buffer before being sent to client. Default is 10000.
+     - `max-buffer-newline` - same as above, but trigger happens only if newline character was encountered. Default is 100.
+     - `max-time` - max time in milliseconds before the buffer is sent to client. Default is 100.
+     - `no-stdout` - don't capture output. Default is false.
+     - `reset-to-defaults` - reset all output settings that were set with magics to defaults
  
 ### Supported Libraries
 

--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ dependencies {
     compile 'khttp:khttp:1.0.0'
     compile 'org.zeromq:jeromq:0.3.5'
     compile 'com.beust:klaxon:5.2'
+    compile 'com.github.ajalt:clikt:2.3.0'
     runtime 'org.slf4j:slf4j-simple:1.7.25'
     runtime "org.jetbrains.kotlin:jcabi-aether:1.0-dev-3"
     runtime "org.sonatype.aether:aether-api:1.13.1"

--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,10 @@ allprojects {
     }
 
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-        testCompile 'junit:junit:4.12'
-        testCompile "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+        testImplementation 'junit:junit:4.12'
+        testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     }
 
     ext {

--- a/doc/magics.md
+++ b/doc/magics.md
@@ -1,0 +1,14 @@
+# Line magics
+The following line magics are supported:
+ - `%use <lib1>, <lib2> ...` - injects code for supported libraries: artifact resolution, default imports, initialization code, type renderers
+ - `%trackClasspath` - logs any changes of current classpath. Useful for debugging artifact resolution failures
+ - `%trackExecution` - logs pieces of code that are going to be executed. Useful for debugging of libraries support
+ - `%output [--max-cell-size=N] [--max-buffer=N] [--max-buffer-newline=N] [--max-time=N] [--no-stdout] [--reset-to-defaults]` - 
+ output capturing settings.
+     - `max-cell-size` specifies the characters count which may be printed to stdout. Default is 100000.
+     - `max-buffer` - max characters count stored in internal buffer before being sent to client. Default is 10000.
+     - `max-buffer-newline` - same as above, but trigger happens only if newline character was encountered. Default is 100.
+     - `max-time` - max time in milliseconds before the buffer is sent to client. Default is 100.
+     - `no-stdout` - don't capture output. Default is false.
+     - `reset-to-defaults` - reset all output settings that were set with magics to defaults
+ 

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
@@ -42,7 +42,7 @@ enum class JupyterSockets {
 
 data class OutputConfig(
         var captureOutput: Boolean = true,
-        var captureBufferTimeLimitMs: Int = 100,
+        var captureBufferTimeLimitMs: Long = 100,
         var captureBufferMaxSize: Int = 1000,
         var cellOutputMaxSize: Int = 100000,
         var captureNewlineBufferSize: Int = 100

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
@@ -40,6 +40,22 @@ enum class JupyterSockets {
     iopub
 }
 
+data class OutputConfig(
+        var captureOutput: Boolean = true,
+        var captureBufferTimeLimitMs: Int = 100,
+        var captureBufferMaxSize: Int = 1000,
+        var cellOutputMaxSize: Int = 100000,
+        var captureNewlineBufferSize: Int = 100
+) {
+    fun assign(other: OutputConfig) {
+        captureOutput = other.captureOutput
+        captureBufferTimeLimitMs = other.captureBufferTimeLimitMs
+        captureBufferMaxSize = other.captureBufferMaxSize
+        cellOutputMaxSize = other.cellOutputMaxSize
+        captureNewlineBufferSize = other.captureNewlineBufferSize
+    }
+}
+
 data class RuntimeKernelProperties(val map: Map<String, String>) {
     val version: String
         get() = map["version"] ?: "unspecified"

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/connection.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/connection.kt
@@ -18,7 +18,14 @@ class JupyterConnection(val config: KernelConfig): Closeable {
         init {
             val port = config.ports[socket.ordinal]
             bind("${config.transport}://*:$port")
-            Thread.sleep(200)
+            if (type == ZMQ.PUB) {
+                // Workaround to prevent losing few first messages on kernel startup
+                // For more information on losing messages see this scheme:
+                // http://zguide.zeromq.org/page:all#Missing-Message-Problem-Solver
+                // It seems we cannot do correct sync because messaging protocol
+                // doesn't support this. Value of 500 ms was chosen experimentally.
+                Thread.sleep(500)
+            }
             log.debug("[$name] listen: ${config.transport}://*:$port")
         }
 

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
@@ -1,12 +1,18 @@
 package org.jetbrains.kotlin.jupyter
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
 import org.jetbrains.kotlin.jupyter.repl.spark.ClassWriter
 
 enum class ReplLineMagics(val desc: String, val argumentsUsage: String? = null, val visibleInHelp: Boolean = true) {
     use("include supported libraries", "klaxon(5.0.1), lets-plot"),
     trackClasspath("log current classpath changes"),
     trackExecution("log code that is going to be executed in repl", visibleInHelp = false),
-    dumpClassesForSpark("stores compiled repl classes in special folder for Spark integration", visibleInHelp = false)
+    dumpClassesForSpark("stores compiled repl classes in special folder for Spark integration", visibleInHelp = false),
+    output("setup output settings", "--max 1000 --no-stdout --time-interval-ms 100 --buffer-limit 400")
 }
 
 fun processMagics(repl: ReplForJupyter, code: String): String {
@@ -14,6 +20,35 @@ fun processMagics(repl: ReplForJupyter, code: String): String {
     val sb = StringBuilder()
     var nextSearchIndex = 0
     var nextCopyIndex = 0
+
+    val outputParser = repl.outputConfig.let { conf ->
+        object : CliktCommand() {
+            val defaultConfig = OutputConfig()
+
+            val max: Int by option("--max-cell-size", help = "Maximum cell output").int().default(conf.cellOutputMaxSize)
+            val maxBuffer: Int by option("--max-buffer", help = "Maximum buffer size").int().default(conf.captureBufferMaxSize)
+            val maxBufferNewline: Int by option("--max-buffer-newline", help = "Maximum buffer size when newline got").int().default(conf.captureNewlineBufferSize)
+            val maxTimeInterval: Int by option("--max-time", help = "Maximum time wait for output to accumulate").int().default(conf.captureBufferTimeLimitMs)
+            val dontCaptureStdout: Boolean by option("--no-stdout", help = "Don't capture output").flag(default = !conf.captureOutput)
+            val reset: Boolean by option("--reset-to-defaults", help = "Reset to defaults").flag()
+
+            override fun run() {
+                if (reset) {
+                    conf.assign(defaultConfig)
+                    return
+                }
+                conf.assign(
+                        OutputConfig(
+                                !dontCaptureStdout,
+                                maxTimeInterval,
+                                maxBuffer,
+                                max,
+                                maxBufferNewline
+                        )
+                )
+            }
+        }
+    }
 
     while (true) {
 
@@ -54,6 +89,9 @@ fun processMagics(repl: ReplForJupyter, code: String): String {
                 ReplLineMagics.use -> {
                     if (arg == null) throw ReplCompilerException("Need some arguments for 'use' command")
                     repl.librariesCodeGenerator.processNewLibraries(repl, arg)
+                }
+                ReplLineMagics.output -> {
+                    outputParser.parse((arg ?: "").split(" "))
                 }
             }
             nextCopyIndex = magicEnd

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
+import com.github.ajalt.clikt.parameters.types.long
 import org.jetbrains.kotlin.jupyter.repl.spark.ClassWriter
 
 enum class ReplLineMagics(val desc: String, val argumentsUsage: String? = null, val visibleInHelp: Boolean = true) {
@@ -28,7 +29,7 @@ fun processMagics(repl: ReplForJupyter, code: String): String {
             val max: Int by option("--max-cell-size", help = "Maximum cell output").int().default(conf.cellOutputMaxSize)
             val maxBuffer: Int by option("--max-buffer", help = "Maximum buffer size").int().default(conf.captureBufferMaxSize)
             val maxBufferNewline: Int by option("--max-buffer-newline", help = "Maximum buffer size when newline got").int().default(conf.captureNewlineBufferSize)
-            val maxTimeInterval: Int by option("--max-time", help = "Maximum time wait for output to accumulate").int().default(conf.captureBufferTimeLimitMs)
+            val maxTimeInterval: Long by option("--max-time", help = "Maximum time wait for output to accumulate").long().default(conf.captureBufferTimeLimitMs)
             val dontCaptureStdout: Boolean by option("--no-stdout", help = "Don't capture output").flag(default = !conf.captureOutput)
             val reset: Boolean by option("--reset-to-defaults", help = "Reset to defaults").flag()
 

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/magics.kt
@@ -12,7 +12,7 @@ enum class ReplLineMagics(val desc: String, val argumentsUsage: String? = null, 
     trackClasspath("log current classpath changes"),
     trackExecution("log code that is going to be executed in repl", visibleInHelp = false),
     dumpClassesForSpark("stores compiled repl classes in special folder for Spark integration", visibleInHelp = false),
-    output("setup output settings", "--max 1000 --no-stdout --time-interval-ms 100 --buffer-limit 400")
+    output("setup output settings", "--max-cell-size=1000 --no-stdout --max-time=100 --max-buffer=400")
 }
 
 fun processMagics(repl: ReplForJupyter, code: String): String {

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
@@ -40,6 +40,8 @@ class ReplCompilerException(val errorResult: ReplCompileResult.Error) : ReplExce
 class ReplForJupyter(val scriptClasspath: List<File> = emptyList(),
                      val config: ResolverConfig? = null) {
 
+    val outputConfig = OutputConfig()
+
     private val resolver = JupyterScriptDependenciesResolver(config)
 
     private val renderers = config?.let {

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.OutputStream
 import java.io.PrintStream
+import java.util.concurrent.atomic.AtomicInteger
 
 class CapturingStreamTests {
     private val nullOStream = object: OutputStream() {
@@ -58,16 +59,15 @@ class CapturingStreamTests {
         val contents = "0123456789\nfortran".toByteArray()
         val expected = arrayOf("012", "345", "678", "9\n", "for", "tra", "n")
 
-        var i = 0
+        val i = AtomicInteger()
         val s = getStream(maxBufferSize = 3) {
-            assertEquals(expected[i], it)
-            ++i
+            assertEquals(expected[i.getAndIncrement()], it)
         }
 
         s.write(contents)
         s.flush()
 
-        assertEquals(expected.size, i)
+        assertEquals(expected.size, i.get())
     }
 
     @Test
@@ -75,16 +75,15 @@ class CapturingStreamTests {
         val contents = "12345\n12\n3451234567890".toByteArray()
         val expected = arrayOf("12345\n", "12\n", "345123456", "7890")
 
-        var i = 0
+        val i = AtomicInteger()
         val s = getStream(maxBufferSize = 9, maxBufferNewlineSize = 6) {
-            assertEquals(expected[i], it)
-            ++i
+            assertEquals(expected[i.getAndIncrement()], it)
         }
 
         s.write(contents)
         s.flush()
 
-        assertEquals(expected.size, i)
+        assertEquals(expected.size, i.get())
     }
     
     @Test
@@ -92,10 +91,9 @@ class CapturingStreamTests {
         val strings = arrayOf("11", "22", "33", "44", "55", "66")
         val expected = arrayOf("1122", "3344", "5566")
 
-        var i = 0
+        val i = AtomicInteger(0)
         val s = getStream(maxBufferLifeTimeMs = 1000) {
-            assertEquals(expected[i], it)
-            ++i
+            assertEquals(expected[i.getAndIncrement()], it)
         }
 
         strings.forEach {
@@ -105,6 +103,6 @@ class CapturingStreamTests {
 
         s.flush()
 
-        assertEquals(expected.size, i)
+        assertEquals(expected.size, i.get())
     }
 }

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
@@ -1,0 +1,110 @@
+package org.jetbrains.kotlin.jupyter.test
+
+import org.jetbrains.kotlin.jupyter.CapturingOutputStream
+import org.jetbrains.kotlin.jupyter.OutputConfig
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.OutputStream
+import java.io.PrintStream
+
+class CapturingStreamTests {
+    private val nullOStream = object: OutputStream() {
+        override fun write(b: Int) {
+        }
+    }
+
+    private fun getStream(stdout: OutputStream = nullOStream,
+                          captureOutput: Boolean = true,
+                          maxBufferLifeTimeMs: Int = 1000,
+                          maxBufferSize: Int = 1000,
+                          maxOutputSize: Int = 1000,
+                          maxBufferNewlineSize: Int = 1,
+                          onCaptured: (String) -> Unit = {}): CapturingOutputStream {
+
+        val printStream = PrintStream(stdout, false, "UTF-8")
+        val config = OutputConfig(captureOutput, maxBufferLifeTimeMs, maxBufferSize, maxOutputSize, maxBufferNewlineSize)
+        return CapturingOutputStream(printStream, config, captureOutput, onCaptured)
+    }
+
+    @Test
+    fun testMaxOutputSizeOk() {
+        val s = getStream(maxOutputSize = 6)
+        s.write("kotlin".toByteArray())
+    }
+
+    @Test
+    fun testMaxOutputSizeError() {
+        val s = getStream(maxOutputSize = 3)
+        s.write("java".toByteArray())
+        assertArrayEquals("jav".toByteArray(), s.capturedOutput.toByteArray())
+    }
+
+    @Test
+    fun testOutputCapturingFlag() {
+        val contents = "abc".toByteArray()
+
+        val s1 = getStream(captureOutput = false)
+        s1.write(contents)
+        assertEquals(0, s1.capturedOutput.size())
+
+        val s2 = getStream(captureOutput = true)
+        s2.write(contents)
+        assertArrayEquals(contents, s2.capturedOutput.toByteArray())
+    }
+
+    @Test
+    fun testMaxBufferSize() {
+        val contents = "0123456789\nfortran".toByteArray()
+        val expected = arrayOf("012", "345", "678", "9\n", "for", "tra", "n")
+
+        var i = 0
+        val s = getStream(maxBufferSize = 3) {
+            assertEquals(expected[i], it)
+            ++i
+        }
+
+        s.write(contents)
+        s.flush()
+
+        assertEquals(expected.size, i)
+    }
+
+    @Test
+    fun testNewlineBufferSize() {
+        val contents = "12345\n12\n3451234567890".toByteArray()
+        val expected = arrayOf("12345\n", "12\n345", "123456789", "0")
+
+        var i = 0
+        val s = getStream(maxBufferSize = 9, maxBufferNewlineSize = 6) {
+            assertEquals(expected[i], it)
+            ++i
+        }
+
+        s.write(contents)
+        s.flush()
+
+        assertEquals(expected.size, i)
+    }
+    
+    @Test
+    fun testMaxBufferLifeTime() {
+        val strings = arrayOf("c ", "a", "ada ", "b", "scala ", "c")
+        val expected = arrayOf("c a", "ada b", "scala c")
+
+        var i = 0
+        val s = getStream(maxBufferLifeTimeMs = 1000) {
+            assertEquals(expected[i], it)
+            ++i
+        }
+
+        strings.forEach {
+            Thread.sleep(600)
+            s.write(it.toByteArray())
+        }
+
+        s.flush()
+
+        assertEquals(expected.size, i)
+    }
+}

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/capturingStreamTests.kt
@@ -16,7 +16,7 @@ class CapturingStreamTests {
 
     private fun getStream(stdout: OutputStream = nullOStream,
                           captureOutput: Boolean = true,
-                          maxBufferLifeTimeMs: Int = 1000,
+                          maxBufferLifeTimeMs: Long = 1000,
                           maxBufferSize: Int = 1000,
                           maxOutputSize: Int = 1000,
                           maxBufferNewlineSize: Int = 1,
@@ -37,7 +37,7 @@ class CapturingStreamTests {
     fun testMaxOutputSizeError() {
         val s = getStream(maxOutputSize = 3)
         s.write("java".toByteArray())
-        assertArrayEquals("jav".toByteArray(), s.capturedOutput.toByteArray())
+        assertArrayEquals("jav".toByteArray(), s.contents)
     }
 
     @Test
@@ -46,11 +46,11 @@ class CapturingStreamTests {
 
         val s1 = getStream(captureOutput = false)
         s1.write(contents)
-        assertEquals(0, s1.capturedOutput.size())
+        assertEquals(0, s1.contents.size)
 
         val s2 = getStream(captureOutput = true)
         s2.write(contents)
-        assertArrayEquals(contents, s2.capturedOutput.toByteArray())
+        assertArrayEquals(contents, s2.contents)
     }
 
     @Test
@@ -73,7 +73,7 @@ class CapturingStreamTests {
     @Test
     fun testNewlineBufferSize() {
         val contents = "12345\n12\n3451234567890".toByteArray()
-        val expected = arrayOf("12345\n", "12\n345", "123456789", "0")
+        val expected = arrayOf("12345\n", "12\n", "345123456", "7890")
 
         var i = 0
         val s = getStream(maxBufferSize = 9, maxBufferNewlineSize = 6) {
@@ -89,8 +89,8 @@ class CapturingStreamTests {
     
     @Test
     fun testMaxBufferLifeTime() {
-        val strings = arrayOf("c ", "a", "ada ", "b", "scala ", "c")
-        val expected = arrayOf("c a", "ada b", "scala c")
+        val strings = arrayOf("11", "22", "33", "44", "55", "66")
+        val expected = arrayOf("1122", "3344", "5566")
 
         var i = 0
         val s = getStream(maxBufferLifeTimeMs = 1000) {
@@ -99,7 +99,7 @@ class CapturingStreamTests {
         }
 
         strings.forEach {
-            Thread.sleep(600)
+            Thread.sleep(450)
             s.write(it.toByteArray())
         }
 

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/executeTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/executeTests.kt
@@ -12,7 +12,6 @@ fun Message.type(): String {
 
 class ExecuteTests : KernelServerTestsBase() {
 
-    @Synchronized
     private fun doExecute(code : String, hasResult: Boolean = true, ioPubChecker : (ZMQ.Socket) -> Unit = {}) : Any? {
         val context = ZMQ.context(1)
         val shell = context.socket(ZMQ.REQ)

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/kernelServerTestsBase.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/kernelServerTestsBase.kt
@@ -22,7 +22,7 @@ open class KernelServerTestsBase {
 
     protected val hmac = HMAC(config.signatureScheme, config.signatureKey)
 
-    protected var server: Thread? = null
+    private var server: Thread? = null
 
     protected val messageId = listOf(byteArrayOf(1))
 
@@ -33,11 +33,10 @@ open class KernelServerTestsBase {
 
     @After
     fun teardownServer() {
-        Thread.sleep(100)
         server?.interrupt()
     }
 
-    fun ZMQ.Socket.sendMessage(msgType: String, content : JsonObject): Unit {
+    fun ZMQ.Socket.sendMessage(msgType: String, content : JsonObject) {
         sendMessage(Message(id = messageId, header = makeHeader(msgType), content = content), hmac)
     }
 
@@ -45,8 +44,8 @@ open class KernelServerTestsBase {
 
     companion object {
         private val rng = Random()
-        private val portRangeStart = 32768
-        private val portRangeEnd = 65536
+        private const val portRangeStart = 32768
+        private const val portRangeEnd = 65536
 
         fun randomPort(): Int =
                 generateSequence { portRangeStart + rng.nextInt(portRangeEnd - portRangeStart) }.find {

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/kernelServerTestsBase.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/kernelServerTestsBase.kt
@@ -44,18 +44,22 @@ open class KernelServerTestsBase {
 
     companion object {
         private val rng = Random()
+        private val usedPorts = mutableSetOf<Int>()
         private const val portRangeStart = 32768
         private const val portRangeEnd = 65536
 
-        fun randomPort(): Int =
-                generateSequence { portRangeStart + rng.nextInt(portRangeEnd - portRangeStart) }.find {
-                    try {
-                        ServerSocket(it).close()
-                        true
-                    }
-                    catch (e: IOException) {
-                        false
-                    }
-                }!!
+        @Synchronized
+        fun randomPort(): Int {
+            val res = generateSequence { portRangeStart + rng.nextInt(portRangeEnd - portRangeStart) }.find {
+                try {
+                    ServerSocket(it).close()
+                    !usedPorts.contains(it)
+                } catch (e: IOException) {
+                    false
+                }
+            }!!
+            usedPorts.add(res)
+            return res
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/replTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/replTests.kt
@@ -3,8 +3,6 @@ package org.jetbrains.kotlin.jupyter.test
 import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
 import jupyter.kotlin.MimeTypedResult
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import org.jetbrains.kotlin.jupyter.*
 import org.jetbrains.kotlin.jupyter.repl.completion.CompletionResultSuccess
 import org.junit.Assert
@@ -72,6 +70,28 @@ class ReplTest {
         val res = repl.eval("Out[1]")
         assertEquals(2, res.resultValue)
         assertFails { repl.eval("Out[3]") }
+    }
+
+    @Test
+    fun TestOutputMagic() {
+        val repl = ReplForJupyter(classpath)
+        repl.preprocessCode("%output --max-cell-size=100500 --no-stdout")
+        assertEquals(OutputConfig(
+                cellOutputMaxSize = 100500,
+                captureOutput = false
+        ), repl.outputConfig)
+
+        repl.preprocessCode("%output --max-buffer=42 --max-buffer-newline=33 --max-time=2000")
+        assertEquals(OutputConfig(
+                cellOutputMaxSize = 100500,
+                captureOutput = false,
+                captureBufferMaxSize = 42,
+                captureNewlineBufferSize = 33,
+                captureBufferTimeLimitMs = 2000
+        ), repl.outputConfig)
+
+        repl.preprocessCode("%output --reset-to-defaults")
+        assertEquals(OutputConfig(), repl.outputConfig)
     }
 
     @Test


### PR DESCRIPTION
Closes #32 
Send output to client before the whole cell is calculated. May be triggered by:
1) Exceeding buffer limit
2) Newline symbol in output
3) Some time after no flushing was performed

New and old functionality was covered with tests.
New config parameters were added