### PR TITLE
kotlinVersion to 1.3.71 to make teamCity build great again (or not)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ import java.util.stream.Collectors
 
 buildscript {
     ext.shadowJarVersion = "5.2.0"
-    ext.kotlinVersion = '1.3.70-eap-3'
+    ext.kotlinVersion = '1.3.71'
     ext.baseVersion = '0.7.41'
     repositories {
         jcenter()


### PR DESCRIPTION
ext.kotlinVersion version correction 
1.3.70-eap-3 not longer available