### PR TITLE
Move branch and formatVersion to runtime properties

### DIFF
--- a/buildSrc/src/main/kotlin/install.kt
+++ b/buildSrc/src/main/kotlin/install.kt
@@ -25,6 +25,7 @@ interface InstallOptions {
     val nbExtensionPath: Path
 
     val librariesPath: String
+    val librariesPropertiesPath: Path
     val jarsPath: String
     val configDir: String
     val jarArgsFile: String

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/util.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/util.kt
@@ -39,7 +39,7 @@ fun <T, R> Deferred<T>.asyncLet(selector: suspend (T) -> R): Deferred<R> = this.
 fun <T> Deferred<T>.awaitBlocking(): T = if (isCompleted) getCompleted() else runBlocking { await() }
 
 fun String.parseIniConfig() =
-        split("\n").map { it.split('=') }.filter { it.count() == 2 }.map { it[0] to it[1] }.toMap()
+        lineSequence().map { it.split('=') }.filter { it.count() == 2 }.map { it[0] to it[1] }.toMap()
 
 fun List<String>.joinToLines() = joinToString("\n")
 

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/configTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/configTests.kt
@@ -1,0 +1,35 @@
+package org.jetbrains.kotlin.jupyter.test
+
+import org.jetbrains.kotlin.jupyter.*
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConfigTest {
+    @Test
+    fun testBranch() {
+        val branch = runtimeProperties.currentBranch
+        log.debug("Runtime git branch is: $branch")
+        assertEquals(-1, branch.indexOf('/'), "Branch name should be simple")
+        assertTrue(branch.isNotBlank(), "Branch name shouldn't be blank")
+    }
+
+    @Test
+    fun testLibrariesProperties() {
+        val format = runtimeProperties.librariesFormatVersion
+        log.debug("Runtime libs format is: $format")
+
+        assertTrue(format in 2..1000)
+        val localProperties = File("$LibrariesDir/$LibraryPropertiesFile").readText().parseIniConfig()
+        assertEquals(localProperties["formatVersion"], format.toString())
+    }
+
+    @Test
+    fun testVersion() {
+        val version = runtimeProperties.version
+        log.debug("Runtime version is: $version")
+
+        assertTrue(version.matches(Regex("""\d+(\.\d+){3}(\.dev\d+)?""")))
+    }
+}


### PR DESCRIPTION
Branch and format version were actually defined in several different places, and it might be easy to forget to modify it in both places. We've actually forgot to do so, and that led to #66 

This PR places build branch and format version to runtime properties `.ini`, so now we should only change formatVersion in one place, and shouldn't change branch at all. If smb wants to build jupyter locally and use libraries branch different from what s/he's on, s/he should set `build.branch` gradle property locally.