### PR TITLE
Allow REPL/Kernel to be embedded and share classes/variables with its caller

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
@@ -83,13 +83,13 @@ class RuntimeKernelProperties(val map: Map<String, String>): ReplRuntimeProperti
     }
 }
 
-data class KernelCfgFile(
+data class KernelJupyterParams(
         val sigScheme: String?,
         val key: String?,
         val ports: List<Int>,
         val transport: String?) {
     companion object {
-        fun fromFile(cfgFile: File): KernelCfgFile {
+        fun fromFile(cfgFile: File): KernelJupyterParams {
             val cfgJson = Parser.default().parse(cfgFile.canonicalPath) as JsonObject
             fun JsonObject.getInt(field: String): Int = int(field)
                     ?: throw RuntimeException("Cannot find $field in $cfgFile")
@@ -98,7 +98,7 @@ data class KernelCfgFile(
             val key = cfgJson.string("key")
             val ports = JupyterSockets.values().map { cfgJson.getInt("${it.name}_port") }
             val transport = cfgJson.string("transport") ?: "tcp"
-            return KernelCfgFile(sigScheme, key, ports, transport)
+            return KernelJupyterParams(sigScheme, key, ports, transport)
         }
     }
 }
@@ -134,11 +134,11 @@ data class KernelConfig(
     companion object {
         fun fromArgs(args: KernelArgs, libraryFactory: LibraryFactory): KernelConfig {
             val (cfgFile, scriptClasspath, homeDir) = args
-            val cfg = KernelCfgFile.fromFile(cfgFile)
+            val cfg = KernelJupyterParams.fromFile(cfgFile)
             return fromConfig(cfg, libraryFactory, scriptClasspath, homeDir)
         }
 
-        fun fromConfig(cfg: KernelCfgFile, libraryFactory: LibraryFactory, scriptClasspath: List<File>, homeDir: File?, embedded: Boolean = false): KernelConfig {
+        fun fromConfig(cfg: KernelJupyterParams, libraryFactory: LibraryFactory, scriptClasspath: List<File>, homeDir: File?, embedded: Boolean = false): KernelConfig {
 
             return KernelConfig(
                     ports = cfg.ports,

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/config.kt
@@ -83,6 +83,26 @@ class RuntimeKernelProperties(val map: Map<String, String>): ReplRuntimeProperti
     }
 }
 
+data class KernelCfgFile(
+        val sigScheme: String?,
+        val key: String?,
+        val ports: List<Int>,
+        val transport: String?) {
+    companion object {
+        fun fromFile(cfgFile: File): KernelCfgFile {
+            val cfgJson = Parser.default().parse(cfgFile.canonicalPath) as JsonObject
+            fun JsonObject.getInt(field: String): Int = int(field)
+                    ?: throw RuntimeException("Cannot find $field in $cfgFile")
+
+            val sigScheme = cfgJson.string("signature_scheme")
+            val key = cfgJson.string("key")
+            val ports = JupyterSockets.values().map { cfgJson.getInt("${it.name}_port") }
+            val transport = cfgJson.string("transport") ?: "tcp"
+            return KernelCfgFile(sigScheme, key, ports, transport)
+        }
+    }
+}
+
 data class KernelConfig(
         val ports: List<Int>,
         val transport: String,
@@ -93,6 +113,7 @@ data class KernelConfig(
         val homeDir: File?,
         val resolverConfig: ResolverConfig?,
         val libraryFactory: LibraryFactory,
+        val embedded: Boolean = false,
 ) {
     fun toArgs(prefix: String = ""): KernelArgs {
         val cfgJson = jsonObject(
@@ -113,21 +134,22 @@ data class KernelConfig(
     companion object {
         fun fromArgs(args: KernelArgs, libraryFactory: LibraryFactory): KernelConfig {
             val (cfgFile, scriptClasspath, homeDir) = args
-            val cfgJson = Parser.default().parse(cfgFile.canonicalPath) as JsonObject
-            fun JsonObject.getInt(field: String): Int = int(field) ?: throw RuntimeException("Cannot find $field in $cfgFile")
+            val cfg = KernelCfgFile.fromFile(cfgFile)
+            return fromConfig(cfg, libraryFactory, scriptClasspath, homeDir)
+        }
 
-            val sigScheme = cfgJson.string("signature_scheme")
-            val key = cfgJson.string("key")
+        fun fromConfig(cfg: KernelCfgFile, libraryFactory: LibraryFactory, scriptClasspath: List<File>, homeDir: File?, embedded: Boolean = false): KernelConfig {
 
             return KernelConfig(
-                    ports = JupyterSockets.values().map { cfgJson.getInt("${it.name}_port") },
-                    transport = cfgJson.string("transport") ?: "tcp",
-                    signatureScheme = sigScheme ?: "hmac1-sha256",
-                    signatureKey = if (sigScheme == null || key == null) "" else key,
+                    ports = cfg.ports,
+                    transport = cfg.transport ?: "tcp",
+                    signatureScheme = cfg.sigScheme ?: "hmac1-sha256",
+                    signatureKey = if (cfg.sigScheme == null || cfg.key == null) "" else cfg.key,
                     scriptClasspath = scriptClasspath,
                     homeDir = homeDir,
                     resolverConfig = homeDir?.let { loadResolverConfig(it.toString(), libraryFactory) },
                     libraryFactory = libraryFactory,
+                    embedded = embedded,
             )
         }
     }

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
@@ -75,6 +75,14 @@ fun main(vararg args: String) {
     }
 }
 
+fun embedKernel(cfgFile: File) {
+    val cp = System.getProperty("java.class.path").split(File.pathSeparator).toTypedArray().map { File(it) }
+    val config = KernelConfig.fromConfig(
+            KernelCfgFile.fromFile(cfgFile),
+            LibraryFactory.EMPTY, cp, null, true)
+    kernelServer(config)
+}
+
 fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties) {
     log.info("Starting server with config: $config")
 

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
@@ -75,15 +75,16 @@ fun main(vararg args: String) {
     }
 }
 
-fun embedKernel(cfgFile: File) {
+fun embedKernel(cfgFile: File, libraryFactory: LibraryFactory?, scriptReceivers: List<Any>?) {
     val cp = System.getProperty("java.class.path").split(File.pathSeparator).toTypedArray().map { File(it) }
     val config = KernelConfig.fromConfig(
             KernelCfgFile.fromFile(cfgFile),
-            LibraryFactory.EMPTY, cp, null, true)
-    kernelServer(config)
+            libraryFactory ?: LibraryFactory.EMPTY,
+            cp, null, true)
+    kernelServer(config, scriptReceivers = scriptReceivers ?: emptyList())
 }
 
-fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties) {
+fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties, scriptReceivers: List<Any> = emptyList()) {
     log.info("Starting server with config: $config")
 
     JupyterConnection(config).use { conn ->
@@ -94,7 +95,7 @@ fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties 
 
         val executionCount = AtomicLong(1)
 
-        val repl = ReplForJupyterImpl(config, runtimeProperties)
+        val repl = ReplForJupyterImpl(config, runtimeProperties, scriptReceivers)
 
         val mainThread = Thread.currentThread()
 

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
@@ -78,7 +78,7 @@ fun main(vararg args: String) {
 fun embedKernel(cfgFile: File, libraryFactory: LibraryFactory?, scriptReceivers: List<Any>?) {
     val cp = System.getProperty("java.class.path").split(File.pathSeparator).toTypedArray().map { File(it) }
     val config = KernelConfig.fromConfig(
-            KernelCfgFile.fromFile(cfgFile),
+            KernelJupyterParams.fromFile(cfgFile),
             libraryFactory ?: LibraryFactory.EMPTY,
             cp, null, true)
     kernelServer(config, scriptReceivers = scriptReceivers ?: emptyList())

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
@@ -66,17 +66,16 @@ fun main(vararg args: String) {
     try {
         log.info("Kernel args: "+ args.joinToString { it })
         val kernelArgs = parseCommandLine(*args)
-        val runtimeProperties = defaultRuntimeProperties
         val libraryPath = (kernelArgs.homeDir ?: File("")).resolve(LibrariesDir)
         val libraryFactory = LibraryFactory.withDefaultDirectoryResolution(libraryPath)
         val kernelConfig = KernelConfig.fromArgs(kernelArgs, libraryFactory)
-        kernelServer(kernelConfig, runtimeProperties)
+        kernelServer(kernelConfig)
     } catch (e: Exception) {
         log.error("exception running kernel with args: \"${args.joinToString()}\"", e)
     }
 }
 
-fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties) {
+fun kernelServer(config: KernelConfig, runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties) {
     log.info("Starting server with config: $config")
 
     JupyterConnection(config).use { conn ->

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/ikotlin.kt
@@ -75,6 +75,11 @@ fun main(vararg args: String) {
     }
 }
 
+/**
+ * This function is to be run in projects which use kernel as a library,
+ * so we don't have a big need in covering it with tests
+ */
+@Suppress("unused")
 fun embedKernel(cfgFile: File, libraryFactory: LibraryFactory?, scriptReceivers: List<Any>?) {
     val cp = System.getProperty("java.class.path").split(File.pathSeparator).toTypedArray().map { File(it) }
     val config = KernelConfig.fromConfig(

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
@@ -135,6 +135,7 @@ class ReplForJupyterImpl(
         override val resolverConfig: ResolverConfig? = null,
         override val runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties,
         private val scriptReceivers: List<Any> = emptyList(),
+        private val embedded: Boolean = false,
 ) : ReplForJupyter, ReplOptions, KotlinKernelHost {
 
     constructor(config: KernelConfig, runtimeProperties: ReplRuntimeProperties, scriptReceivers: List<Any> = emptyList()):
@@ -316,12 +317,14 @@ class ReplForJupyterImpl(
 
     private val evaluatorConfiguration = ScriptEvaluationConfiguration {
         implicitReceivers.invoke(v = scriptReceivers)
-        jvm {
-            val filteringClassLoader = FilteringClassLoader(ClassLoader.getSystemClassLoader()) {
-                it.startsWith("jupyter.kotlin.") || it.startsWith("kotlin.") || (it.startsWith("org.jetbrains.kotlin.") && !it.startsWith("org.jetbrains.kotlin.jupyter."))
+        if (!embedded) {
+            jvm {
+                val filteringClassLoader = FilteringClassLoader(ClassLoader.getSystemClassLoader()) {
+                    it.startsWith("jupyter.kotlin.") || it.startsWith("kotlin.") || (it.startsWith("org.jetbrains.kotlin.") && !it.startsWith("org.jetbrains.kotlin.jupyter."))
+                }
+                val scriptClassloader = URLClassLoader(scriptClasspath.map { it.toURI().toURL() }.toTypedArray(), filteringClassLoader)
+                baseClassLoader(scriptClassloader)
             }
-            val scriptClassloader = URLClassLoader(scriptClasspath.map { it.toURI().toURL() }.toTypedArray(), filteringClassLoader)
-            baseClassLoader(scriptClassloader)
         }
         constructorArgs(this@ReplForJupyterImpl as KotlinKernelHost)
     }

--- a/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/jupyter/repl.kt
@@ -139,7 +139,7 @@ class ReplForJupyterImpl(
 ) : ReplForJupyter, ReplOptions, KotlinKernelHost {
 
     constructor(config: KernelConfig, runtimeProperties: ReplRuntimeProperties, scriptReceivers: List<Any> = emptyList()):
-            this(config.libraryFactory, config.scriptClasspath, config.homeDir, config.resolverConfig, runtimeProperties, scriptReceivers)
+            this(config.libraryFactory, config.scriptClasspath, config.homeDir, config.resolverConfig, runtimeProperties, scriptReceivers, config.embedded)
 
     override val currentBranch: String
         get() = runtimeProperties.currentBranch

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.kotlin.jupyter.test
+
+
+import org.jetbrains.kotlin.jupyter.ReplForJupyterImpl
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+
+class SomeSingleton {
+    companion object {
+        var initialized: Boolean = false
+    }
+}
+
+
+class EmbedReplTest : AbstractReplTest() {
+
+    @Test
+    fun testRepl() {
+        val embeddedClasspath: List<File> = System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
+        val repl = ReplForJupyterImpl(libraryFactory, embeddedClasspath, embedded=true)
+
+        var res = repl.eval("org.jetbrains.kotlin.jupyter.test.SomeSingleton.initialized")
+        assertEquals(false, res.resultValue)
+
+        SomeSingleton.initialized = true
+
+        res = repl.eval("org.jetbrains.kotlin.jupyter.test.SomeSingleton.initialized")
+        assertEquals(true, res.resultValue)
+
+    }
+}

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
@@ -2,6 +2,8 @@ package org.jetbrains.kotlin.jupyter.test
 
 
 import org.jetbrains.kotlin.jupyter.ReplForJupyterImpl
+import org.jetbrains.kotlin.jupyter.ResolverConfig
+import org.jetbrains.kotlin.jupyter.libraries.LibraryFactory
 import org.jetbrains.kotlin.jupyter.test.ReplWithResolverTest.Companion.resolverConfig
 import org.junit.jupiter.api.Test
 import java.io.File

--- a/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlin/jupyter/test/embeddingTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.jupyter.test
 
 
 import org.jetbrains.kotlin.jupyter.ReplForJupyterImpl
+import org.jetbrains.kotlin.jupyter.test.ReplWithResolverTest.Companion.resolverConfig
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
@@ -17,7 +18,7 @@ class SomeSingleton {
 class EmbedReplTest : AbstractReplTest() {
 
     @Test
-    fun testRepl() {
+    fun testSharedStaticVariables() {
         val embeddedClasspath: List<File> = System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
         val repl = ReplForJupyterImpl(libraryFactory, embeddedClasspath, embedded=true)
 
@@ -29,5 +30,18 @@ class EmbedReplTest : AbstractReplTest() {
         res = repl.eval("org.jetbrains.kotlin.jupyter.test.SomeSingleton.initialized")
         assertEquals(true, res.resultValue)
 
+    }
+
+    @Test
+    fun testCustomClasses() {
+        val embeddedClasspath: List<File> = System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
+        val repl = ReplForJupyterImpl(libraryFactory, embeddedClasspath, embedded=true)
+
+        repl.eval("class Point(val x: Int, val y: Int)")
+
+        repl.eval("val p = Point(1,1)")
+
+        val res = repl.eval("p.x")
+        assertEquals(1, res.resultValue)
     }
 }


### PR DESCRIPTION
Currently the Kotlin kernel supports something similar to [IPython.start_kernel](https://ipython.readthedocs.io/en/stable/api/generated/IPython.html#IPython.start_kernel). This PR aims to support something that covers the use cases of [IPython.embed_kernel](https://ipython.readthedocs.io/en/stable/api/generated/IPython.html#IPython.embed_kernel).



#### What this PR provides

An application can now call `org.jetbrains.kotlin.jupyter.iKotlin.kernelServer` directly and pass a desired `KernelConfig` and the runtime properties where the `embedded` property is set to `true` and return the `KernelConfig` as a standard JSON to user in an application specific way.
The user can then run `jupyter console --existing=path/to/kernelconfig.json` to attach a Kotlin REPL to the kernel and run arbitrary Kotlin code inside the application context with the same state as the the application. 


#### What this PR does not allow

This does not allow attaching a Jupyter Notebook to the Kernel. This is a [limitation of Jupyter Notebooks](https://stackoverflow.com/questions/31382405/ipython-notebook-how-to-connect-to-existing-kernel/31385337#31385337) and not the Kotlin kernel.


### Status

This should work already, but I'm currently still writing the actual embedding code for the application I want to use it in, so until then I still consider this PR a draft, but appreciate an feedback on the general idea and current implementation.

EDIT:
The first proof of concept for this already works and I think anything else I wanted to achieve is an issue with the application embedding the kernel. This embedding could be simplified by allowing the embedding Java Application to acess `defaultRuntimeProperties`. I am also feeling unsure if the runtimeproperties is really the right place for the embedding option, and if `KernelArgs`/`KernelConfig` wouldn't be a better place.