### PR TITLE
Make embedKernel arguments nullable

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/ikotlin.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/ikotlin.kt
@@ -80,13 +80,17 @@ fun main(vararg args: String) {
 /**
  * This function is to be run in projects which use kernel as a library,
  * so we don't have a big need in covering it with tests
+ *
+ * The expected use case for this function is embedding into a Java application that doesn't necessarily support extensions written in Kotlin
+ * The signature of this function should thus be simple, and e.g. allow resolutionInfoProvider to be null instead of having to pass EmptyResolutionInfoProvider
+ * because EmptyResolutionInfoProvider is a Kotlin singleton object and it takes a while to understand how to use it from Java code.
  */
 @Suppress("unused")
-fun embedKernel(cfgFile: File, resolutionInfoProvider: ResolutionInfoProvider = EmptyResolutionInfoProvider, scriptReceivers: List<Any>? = null) {
+fun embedKernel(cfgFile: File, resolutionInfoProvider: ResolutionInfoProvider?, scriptReceivers: List<Any>? = null) {
     val cp = System.getProperty("java.class.path").split(File.pathSeparator).toTypedArray().map { File(it) }
     val config = KernelConfig.fromConfig(
         KernelJupyterParams.fromFile(cfgFile),
-        resolutionInfoProvider,
+        resolutionInfoProvider ?: EmptyResolutionInfoProvider,
         cp,
         null,
         true


### PR DESCRIPTION
EmptyResolutionInfoProvider is created by an [object declaration](https://kotlinlang.org/docs/object-declarations.html#object-declarations) which fails to import in pure java code. The `embedKernel` method is intended to be called inside pure Java code that simply has the compiled kotlin kernel jars available as a dependency, but the former signature after the refactor in https://github.com/Kotlin/kotlin-jupyter/commit/782f0882ed5f9e89ad378b4a986591397027721d#diff-3c1c4b1ddbb3338fe28601f266bb3c492ac38a395dafb1c3ad4b60a8ffeedc62R85 makes this impossible. This commit makes the `resolutionInfoProvider` nullable again, which also means that existing code using the method and passing null, still works with the the signature using `ResolutionInfoProvider`

edit 1: I can't see the build details, so I can't debug why this fails, it builds for me locally and `./gradlew check` passes

edit 2: I now know about `.INSTANCE`, so I can just use `resolutionInfoProvider.INSTANCE` instead and it works without requiring this PR. I would argue that allowing a signature that violates the typical Kotlin style in this specific case is still reasonable to make it as easy as possible for Java projects and devs to just call `embedKernel` from an existing Java application without being familiar with the nuances of embedding Kotlin code into a Java project. 