### PR TITLE
Don't kill process when embedded

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
@@ -132,6 +132,9 @@ interface ReplForJupyter {
     val notebook: NotebookImpl
 
     val fileExtension: String
+
+    val isEmbedded: Boolean
+        get() = false
 }
 
 fun <T> ReplForJupyter.execute(callback: ExecutionCallback<T>): T {
@@ -145,7 +148,7 @@ class ReplForJupyterImpl(
     override val resolverConfig: ResolverConfig? = null,
     override val runtimeProperties: ReplRuntimeProperties = defaultRuntimeProperties,
     private val scriptReceivers: List<Any> = emptyList(),
-    private val embedded: Boolean = false,
+    override val isEmbedded: Boolean = false,
 ) : ReplForJupyter, ReplOptions, BaseKernelHost, KotlinKernelHostProvider {
 
     constructor(
@@ -262,7 +265,7 @@ class ReplForJupyterImpl(
 
     private val evaluatorConfiguration = ScriptEvaluationConfiguration {
         implicitReceivers.invoke(v = scriptReceivers)
-        if (!embedded) {
+        if (!isEmbedded) {
             jvm {
                 val filteringClassLoader = FilteringClassLoader(ClassLoader.getSystemClassLoader()) { fqn ->
                     listOf(

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/embeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/embeddingTest.kt
@@ -90,7 +90,7 @@ val testLibraryDefinition2 = LibraryDefinitionImpl(
 class EmbedReplTest : AbstractReplTest() {
     private val repl = run {
         val embeddedClasspath: List<File> = System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
-        ReplForJupyterImpl(resolutionInfoProvider, embeddedClasspath, embedded = true)
+        ReplForJupyterImpl(resolutionInfoProvider, embeddedClasspath, isEmbedded = true)
     }
 
     @Test


### PR DESCRIPTION
This tries is intended as a  fix for https://github.com/GhidraJupyter/ghidra-jupyter-kotlin/issues/2

Using ` exitProcess(0)` will terminate the entire process, but if the kernel is used as a library and embedded in another application, i.e. process this will be terminated too. Instead the code that handles the ShutdownRequest now has a somewhat inelegant check if the kernel is embedded and will instead just throw an `InterruptedException` which is caught in the controlThread loop and leads to the `controlThread` interrupting the `mainThread` so they both terminate and the entire kernel terminates.

Because I don't know why `exitProcess(0)` was used in the first place this will only happen if the kernel is embedded for now, but if this also works for the regular usage this could be simplified to just always throwing an `InterruptedException`