### PR TITLE
Switch to Maven dependencies resolver

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
     implKotlin("scripting-compiler-impl-embeddable")
     implKotlin("scripting-compiler-embeddable")
     implKotlin("scripting-ide-services")
-    implKotlin("main-kts")
+    implKotlin("scripting-dependencies-maven")
     implKotlin("script-util")
     implKotlin("scripting-common")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 # Kotlin kernel for IPython/Jupyter
 
-[Kotlin](https://kotlinlang.org/) (1.5.30-dev-454) kernel for [Jupyter](https://jupyter.org).
+[Kotlin](https://kotlinlang.org/) (1.5.30-dev-598) kernel for [Jupyter](https://jupyter.org).
 
 Beta version. Tested with Jupyter Notebook 6.0.3, Jupyter Lab 1.2.6 and Jupyter Console 6.1.0
 on Windows, Ubuntu Linux and macOS.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # kotlinVersion=1.5.255-SNAPSHOT
-kotlinVersion=1.5.30-dev-454
+kotlinVersion=1.5.30-dev-598
 stableKotlinVersion=1.5.0
 kotlinLanguageLevel=1.5
 stableKotlinLanguageLevel=1.5

--- a/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/annotations.kt
+++ b/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/annotations.kt
@@ -1,18 +1,35 @@
 package jupyter.kotlin
 
-// in case of flat or direct resolvers the value should be a direct path or file name of a jar respectively
-// in case of maven resolver the maven coordinates string is accepted
+/**
+ * Describes the dependency
+ *
+ * @property value Can be one of the following:
+ * - Maven artifact coordinates in the following form:
+ * `<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}`
+ * - Path to the JAR file (absolute or relative to the directory specified in [Repository])
+ */
 @Target(AnnotationTarget.FILE)
 @Repeatable
 @Retention(AnnotationRetention.SOURCE)
 annotation class DependsOn(val value: String = "")
 
-// only flat directory repositories are supported now, so value should be a path to a directory with jars
+/**
+ * Describes the repository which is used for dependency resolution
+ *
+ * @property value Can be one of the following:
+ * - Maven repository URL
+ * - Local directory in which JARs are stored
+ */
 @Target(AnnotationTarget.FILE)
 @Repeatable
 @Retention(AnnotationRetention.SOURCE)
 annotation class Repository(val value: String = "")
 
+/**
+ * Describes compilation arguments used for the compilation of this and all following snippets
+ *
+ * @property values List of free compiler arguments
+ */
 @Target(AnnotationTarget.FILE)
 @Repeatable
 @Retention(AnnotationRetention.SOURCE)

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/dependencies/RemoteResolverWrapper.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/dependencies/RemoteResolverWrapper.kt
@@ -38,11 +38,9 @@ class RemoteResolverWrapper(private val remoteResolver: ExternalDependenciesReso
                     val path = "$HOME_PATH/.ivy2/cache"
                     path.toURLString()
                 },
-            )
-                .map {
-                    "$PREFIX${it.shortcut}" to it
-                }
-                .toMap()
+            ).associateBy {
+                "$PREFIX${it.shortcut}"
+            }
 
         fun hasRepository(repository: RepositoryCoordinates): Boolean {
             return repositories.containsKey(repository.string)

--- a/libraries/serialization.json
+++ b/libraries/serialization.json
@@ -1,7 +1,7 @@
 {
   "description": "Kotlin multi-format reflection-less serialization",
   "properties": {
-    "v": "1.0.1"
+    "v": "1.1.0"
   },
   "link": "https://github.com/Kotlin/kotlinx.serialization",
   "dependencies": [

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/dependencies/JupyterScriptDependenciesResolverImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/dependencies/JupyterScriptDependenciesResolverImpl.kt
@@ -3,7 +3,6 @@ package org.jetbrains.kotlinx.jupyter.dependencies
 import jupyter.kotlin.DependsOn
 import jupyter.kotlin.Repository
 import kotlinx.coroutines.runBlocking
-import org.jetbrains.kotlin.mainKts.impl.IvyResolver
 import org.jetbrains.kotlinx.jupyter.config.getLogger
 import java.io.File
 import kotlin.script.dependencies.ScriptContents
@@ -18,6 +17,7 @@ import kotlin.script.experimental.dependencies.FileSystemDependenciesResolver
 import kotlin.script.experimental.dependencies.RepositoryCoordinates
 import kotlin.script.experimental.dependencies.impl.DependenciesResolverOptionsName
 import kotlin.script.experimental.dependencies.impl.makeExternalDependenciesResolverOptions
+import kotlin.script.experimental.dependencies.maven.MavenDependenciesResolver
 
 open class JupyterScriptDependenciesResolverImpl(resolverConfig: ResolverConfig?) : JupyterScriptDependenciesResolver {
 
@@ -36,7 +36,7 @@ open class JupyterScriptDependenciesResolverImpl(resolverConfig: ResolverConfig?
     init {
         resolver = CompoundDependenciesResolver(
             FileSystemDependenciesResolver(),
-            RemoteResolverWrapper(IvyResolver())
+            RemoteResolverWrapper(MavenDependenciesResolver())
         )
         resolverConfig?.repositories?.forEach { addRepository(it) }
     }

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
@@ -7,7 +7,6 @@ import jupyter.kotlin.KotlinKernelHostProvider
 import jupyter.kotlin.Repository
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlinx.jupyter.api.Code
-import org.jetbrains.kotlinx.jupyter.api.CodePreprocessor
 import org.jetbrains.kotlinx.jupyter.api.ExecutionCallback
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion
@@ -59,7 +58,6 @@ import org.jetbrains.kotlinx.jupyter.repl.impl.SharedReplContext
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.jvm.JvmInline
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.ScriptConfigurationRefinementContext

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,4 +11,8 @@
     <root level="DEBUG">
         <appender-ref ref="STDERR" />
     </root>
+
+    <logger name="org.apache" level="ERROR" />
+    <logger name="httpclient" level="ERROR" />
+    <logger name="org.eclipse.aether" level="INFO" />
 </configuration>

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/ResolverTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/ResolverTests.kt
@@ -1,13 +1,13 @@
 package org.jetbrains.kotlinx.jupyter.test
 
 import kotlinx.coroutines.runBlocking
-import org.jetbrains.kotlin.mainKts.impl.IvyResolver
 import org.junit.jupiter.api.Test
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import kotlin.script.experimental.api.ResultWithDiagnostics
 import kotlin.script.experimental.dependencies.ExternalDependenciesResolver
+import kotlin.script.experimental.dependencies.maven.MavenDependenciesResolver
 import kotlin.test.assertTrue
 
 class ResolverTests {
@@ -23,7 +23,7 @@ class ResolverTests {
 
     @Test
     fun resolveSparkMlLibTest() {
-        val files = IvyResolver().doResolve("org.apache.spark:spark-mllib_2.11:2.4.4")
+        val files = MavenDependenciesResolver().doResolve("org.apache.spark:spark-mllib_2.11:2.4.4")
         log.debug("Downloaded files: ${files.count()}")
         files.forEach {
             log.debug(it.toString())

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/ReplTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/ReplTests.kt
@@ -148,12 +148,7 @@ class ReplTests : AbstractSingleReplTest() {
         val newClasspath = res.metadata.newClasspath
         assertTrue(newClasspath.size >= 2)
 
-        val htmlLibPath = listOf(
-            "org.jetbrains.kotlinx",
-            "kotlinx-html-jvm",
-            "jars",
-            "kotlinx-html-jvm"
-        ).joinToString(File.separator)
+        val htmlLibPath = "org/jetbrains/kotlinx/kotlinx-html-jvm/0.7.2/kotlinx-html-jvm".replace('/', File.separatorChar)
         assertTrue(newClasspath.any { htmlLibPath in it })
     }
 


### PR DESCRIPTION
PRs that need to be merged in Kotlin for this one:

- [x] https://github.com/JetBrains/kotlin/pull/4361
- [x] https://github.com/JetBrains/kotlin/pull/4363

Fixes #121, because mavenLocal is used as cache.
Also fixes #117.
Also adds repository authorization, cc @belovrv 
```kotlin
@file:Repository("https://url", "<username>", "<password>")
```