### PR TITLE
Upgrade to Lets-Plot v2.0.3, Lets-Plot Kotlin API v3.0.0

### DIFF
--- a/libraries/lets-plot-gt.json
+++ b/libraries/lets-plot-gt.json
@@ -2,7 +2,7 @@
   "description": "Lets-Plot visualisation for GeoTools toolkit",
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
   "properties": {
-    "api": "2.0.1",
+    "api": "3.0.0",
     "gt": "[23,)"
   },
   "repositories": [

--- a/libraries/lets-plot.json
+++ b/libraries/lets-plot.json
@@ -1,18 +1,18 @@
 {
   "description": "ggplot-like interactive visualization for Kotlin",
   "properties": {
-    "api": "2.0.1",
-    "lib": "2.0.2",
-    "js": "2.0.2",
+    "api": "3.0.0",
+    "lib": "2.0.3",
+    "js": "2.0.3",
     "isolatedFrame": ""
   },
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
   "dependencies": [
-    "org.jetbrains.lets-plot:lets-plot-kotlin-api-kernel:$api",
+    "org.jetbrains.lets-plot:lets-plot-kotlin-kernel:$api",
     "org.jetbrains.lets-plot:lets-plot-common:$lib",
     "org.jetbrains.lets-plot:lets-plot-image-export:$lib",
-
-    "io.github.microutils:kotlin-logging-jvm:2.0.5"
+    "io.github.microutils:kotlin-logging-jvm:2.0.5",
+    "org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.3"
   ],
   "imports": [
     "jetbrains.letsPlot.*",


### PR DESCRIPTION
Upgrade to Lets-Plot v2.0.3, Lets-Plot Kotlin API v3.0.0
 - Artifact "lets-plot-kotlin-api-kernel" was renamed to "lets-plot-kotlin-kernel"
 - CDN changed to JSDELIVR (was CDNJS)
 - Other: [CHANGELOG](https://github.com/JetBrains/lets-plot-kotlin/blob/master/CHANGELOG.md#300---2021-06-04)