### PR TITLE
Add exceptions rendering

### DIFF
--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/LibraryDefinition.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/LibraryDefinition.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.jupyter.api.FieldHandler
 import org.jetbrains.kotlinx.jupyter.api.FileAnnotationHandler
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion
 import org.jetbrains.kotlinx.jupyter.api.RendererHandler
+import org.jetbrains.kotlinx.jupyter.api.ThrowableRenderer
 
 /**
  * Library definition represents "library" concept in Kotlin kernel.
@@ -102,4 +103,10 @@ interface LibraryDefinition {
      */
     val originalDescriptorText: String?
         get() = null
+
+    /**
+     * Renderers of thrown exceptions
+     */
+    val throwableRenderers: List<ThrowableRenderer>
+        get() = emptyList()
 }

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/LibraryDefinitionImpl.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/LibraryDefinitionImpl.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.jupyter.api.FieldHandler
 import org.jetbrains.kotlinx.jupyter.api.FileAnnotationHandler
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion
 import org.jetbrains.kotlinx.jupyter.api.RendererHandler
+import org.jetbrains.kotlinx.jupyter.api.ThrowableRenderer
 
 /**
  * Trivial implementation of [LibraryDefinition] - simple container.
@@ -21,6 +22,7 @@ class LibraryDefinitionImpl private constructor() : LibraryDefinition {
     override var afterCellExecution: List<AfterCellExecutionCallback> = emptyList()
     override var shutdown: List<ExecutionCallback<*>> = emptyList()
     override var renderers: List<RendererHandler> = emptyList()
+    override var throwableRenderers: List<ThrowableRenderer> = emptyList()
     override var converters: List<FieldHandler> = emptyList()
     override var classAnnotations: List<ClassAnnotationHandler> = emptyList()
     override var fileAnnotations: List<FileAnnotationHandler> = emptyList()

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/renderersHandling.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/renderersHandling.kt
@@ -4,9 +4,8 @@ import kotlinx.serialization.Serializable
 import org.jetbrains.kotlinx.jupyter.api.libraries.ExecutionHost
 import org.jetbrains.kotlinx.jupyter.api.libraries.VariablesSubstitutionAware
 import org.jetbrains.kotlinx.jupyter.util.TypeHandlerCodeExecutionSerializer
+import org.jetbrains.kotlinx.jupyter.util.isSubclassOfCatching
 import kotlin.reflect.KClass
-import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 
 /**
  * Execution interface for type handlers
@@ -136,13 +135,7 @@ class SubtypeRendererTypeHandler(private val superType: KClass<*>, override val 
     }
 
     override fun acceptsType(type: KClass<*>): Boolean {
-        return try {
-            type.isSubclassOf(superType)
-        } catch (e: UnsupportedOperationException) {
-            false
-        } catch (e: KotlinReflectionInternalError) {
-            false
-        }
+        return type.isSubclassOfCatching(superType)
     }
 
     override fun replaceVariables(mapping: Map<String, String>): SubtypeRendererTypeHandler {

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/throwableRendering.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/throwableRendering.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.kotlinx.jupyter.api
+
+import org.jetbrains.kotlinx.jupyter.util.isSubclassOfCatching
+import kotlin.reflect.KClass
+
+interface ThrowableRenderer {
+    fun accepts(throwable: Throwable): Boolean
+
+    fun render(throwable: Throwable): Any
+}
+
+class SubtypeThrowableRenderer<E : Throwable>(
+    private val superType: KClass<E>,
+    private val renderer: (E) -> Any,
+) : ThrowableRenderer {
+    override fun accepts(throwable: Throwable): Boolean {
+        return throwable::class.isSubclassOfCatching(superType)
+    }
+
+    override fun render(throwable: Throwable): Any {
+        @Suppress("UNCHECKED_CAST")
+        return renderer(throwable as E)
+    }
+}

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/util/reflecton.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/util/reflecton.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.kotlinx.jupyter.util
+
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
+
+fun KClass<*>.isSubclassOfCatching(superType: KClass<*>): Boolean {
+    return try {
+        isSubclassOf(superType)
+    } catch (e: UnsupportedOperationException) {
+        false
+    } catch (e: KotlinReflectionInternalError) {
+        false
+    }
+}

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/ThrowableRenderersProcessor.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/ThrowableRenderersProcessor.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.kotlinx.jupyter.codegen
+
+import org.jetbrains.kotlinx.jupyter.api.ThrowableRenderer
+
+interface ThrowableRenderersProcessor {
+    fun renderThrowable(throwable: Throwable): Any?
+
+    fun register(renderer: ThrowableRenderer)
+}

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/ThrowableRenderersProcessorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/ThrowableRenderersProcessorImpl.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.kotlinx.jupyter.codegen
+
+import org.jetbrains.kotlinx.jupyter.api.ThrowableRenderer
+
+class ThrowableRenderersProcessorImpl : ThrowableRenderersProcessor {
+    private val renderers = mutableListOf<ThrowableRenderer>()
+
+    override fun renderThrowable(throwable: Throwable): Any? {
+        return renderers.firstOrNull { it.accepts(throwable) }?.render(throwable)
+    }
+
+    override fun register(renderer: ThrowableRenderer) {
+        renderers.add(renderer)
+    }
+}

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl.kt
@@ -20,6 +20,8 @@ import org.jetbrains.kotlinx.jupyter.codegen.FileAnnotationsProcessor
 import org.jetbrains.kotlinx.jupyter.codegen.FileAnnotationsProcessorImpl
 import org.jetbrains.kotlinx.jupyter.codegen.RenderersProcessorImpl
 import org.jetbrains.kotlinx.jupyter.codegen.ResultsRenderersProcessor
+import org.jetbrains.kotlinx.jupyter.codegen.ThrowableRenderersProcessor
+import org.jetbrains.kotlinx.jupyter.codegen.ThrowableRenderersProcessorImpl
 import org.jetbrains.kotlinx.jupyter.common.looksLikeReplCommand
 import org.jetbrains.kotlinx.jupyter.compiler.CompilerArgsConfigurator
 import org.jetbrains.kotlinx.jupyter.compiler.DefaultCompilerArgsConfigurator
@@ -138,6 +140,8 @@ interface ReplForJupyter {
     val runtimeProperties: ReplRuntimeProperties
 
     val resolutionInfoProvider: ResolutionInfoProvider
+
+    val throwableRenderersProcessor: ThrowableRenderersProcessor
 
     var outputConfig: OutputConfig
 
@@ -325,6 +329,8 @@ class ReplForJupyterImpl(
         registerDefaultRenderers()
     }
 
+    override val throwableRenderersProcessor: ThrowableRenderersProcessor = ThrowableRenderersProcessorImpl()
+
     private val fieldsProcessor: FieldsProcessor = FieldsProcessorImpl(contextUpdater)
 
     private val classAnnotationsProcessor: ClassAnnotationsProcessor = ClassAnnotationsProcessorImpl()
@@ -338,6 +344,7 @@ class ReplForJupyterImpl(
         fileAnnotationsProcessor,
         fieldsProcessor,
         renderersProcessor,
+        throwableRenderersProcessor,
         codePreprocessor,
         resourcesProcessor,
         librariesProcessor,

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/evalResults.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/evalResults.kt
@@ -25,6 +25,10 @@ data class EvalResultEx(
     val metadata: EvaluatedSnippetMetadata,
 )
 
+fun rawToResponse(value: Any?, notebook: Notebook, metadata: EvaluatedSnippetMetadata = EvaluatedSnippetMetadata.EMPTY): Response {
+    return OkResponseWithMessage(value.toDisplayResult(notebook), metadata)
+}
+
 fun EvalResult.toResponse(notebook: Notebook): Response {
-    return OkResponseWithMessage(resultValue.toDisplayResult(notebook), metadata)
+    return rawToResponse(resultValue, notebook, metadata)
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/CellExecutorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/CellExecutorImpl.kt
@@ -125,6 +125,7 @@ internal class CellExecutorImpl(private val replContext: SharedReplContext) : Ce
                 library.init.forEach(::runChild)
             }
             library.renderers.mapNotNull(sharedContext.renderersProcessor::register).joinToLines().let(::runChild)
+            library.throwableRenderers.forEach(sharedContext.throwableRenderersProcessor::register)
             library.converters.forEach(sharedContext.fieldsProcessor::register)
             library.classAnnotations.forEach(sharedContext.classAnnotationsProcessor::register)
             library.fileAnnotations.forEach(sharedContext.fileAnnotationsProcessor::register)

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/SharedReplContext.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/SharedReplContext.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlinx.jupyter.codegen.ClassAnnotationsProcessor
 import org.jetbrains.kotlinx.jupyter.codegen.FieldsProcessor
 import org.jetbrains.kotlinx.jupyter.codegen.FileAnnotationsProcessor
 import org.jetbrains.kotlinx.jupyter.codegen.ResultsRenderersProcessor
+import org.jetbrains.kotlinx.jupyter.codegen.ThrowableRenderersProcessor
 import org.jetbrains.kotlinx.jupyter.libraries.LibrariesProcessor
 import org.jetbrains.kotlinx.jupyter.libraries.LibrariesScanner
 import org.jetbrains.kotlinx.jupyter.libraries.LibraryResourcesProcessor
@@ -18,6 +19,7 @@ internal data class SharedReplContext(
     val fileAnnotationsProcessor: FileAnnotationsProcessor,
     val fieldsProcessor: FieldsProcessor,
     val renderersProcessor: ResultsRenderersProcessor,
+    val throwableRenderersProcessor: ThrowableRenderersProcessor,
     val codePreprocessor: CompoundCodePreprocessor,
     val resourcesProcessor: LibraryResourcesProcessor,
     val librariesProcessor: LibrariesProcessor,


### PR DESCRIPTION
This PR adds the ability to render exceptions via API. Renderers should return `DisplayResult`

Fix #332