### PR TITLE
Support display id in `display(value)` API.

### DIFF
--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/KotlinKernelHost.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/KotlinKernelHost.kt
@@ -11,7 +11,7 @@ interface KotlinKernelHost {
      * Try to display the given value. It is only displayed if it's an instance of [Renderable]
      * or may be converted to it
      */
-    fun display(value: Any)
+    fun display(value: Any, id: String? = null)
 
     /**
      * Updates display data with given [id] with the new [value]

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/results.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/results.kt
@@ -47,7 +47,7 @@ interface DisplayResult : Renderable {
      * @param additionalMetadata Additional reply metadata
      * @return Display JSON
      */
-    fun toJson(additionalMetadata: JsonObject = JsonObject(mapOf())): JsonObject
+    fun toJson(additionalMetadata: JsonObject = JsonObject(mapOf()), overrideId: String? = null): JsonObject
 
     /**
      * Renders display result, generally should return `this`
@@ -83,6 +83,11 @@ fun DisplayResult?.toJson(): JsonObject {
     return Json.encodeToJsonElement(mapOf("data" to null, "metadata" to JsonObject(mapOf()))) as JsonObject
 }
 
+fun DisplayResult.withId(id: String) = if(id == this.id) this else object: DisplayResult {
+    override fun toJson(additionalMetadata: JsonObject, overrideId: String?) = this@withId.toJson(additionalMetadata, overrideId ?: id)
+    override val id = id
+}
+
 /**
  * Sets display ID to JSON.
  * If ID was not set, sets it to [id] and returns it back
@@ -112,7 +117,7 @@ class MimeTypedResult(
     var isolatedHtml: Boolean = false,
     override val id: String? = null
 ) : Map<String, String> by mimeData, DisplayResult {
-    override fun toJson(additionalMetadata: JsonObject): JsonObject {
+    override fun toJson(additionalMetadata: JsonObject, overrideId: String?): JsonObject {
         val metadata = HashMap<String, JsonElement>().apply {
             if (isolatedHtml) put("text/html", Json.encodeToJsonElement(mapOf("isolated" to true)))
             additionalMetadata.forEach { key, value ->
@@ -124,16 +129,8 @@ class MimeTypedResult(
             "data" to Json.encodeToJsonElement(mimeData),
             "metadata" to Json.encodeToJsonElement(metadata)
         )
-        result.setDisplayId(id)
+        result.setDisplayId(overrideId ?: id)
         return Json.encodeToJsonElement(result) as JsonObject
-    }
-
-    /**
-     * Adds an [id] to this [MimeTypedResult] object
-     */
-    @Suppress("unused")
-    fun withId(id: String?): MimeTypedResult {
-        return MimeTypedResult(mimeData, isolatedHtml, id)
     }
 }
 

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/results.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/results.kt
@@ -83,7 +83,8 @@ fun DisplayResult?.toJson(): JsonObject {
     return Json.encodeToJsonElement(mapOf("data" to null, "metadata" to JsonObject(mapOf()))) as JsonObject
 }
 
-fun DisplayResult.withId(id: String) = if(id == this.id) this else object: DisplayResult {
+@Suppress("unused")
+fun DisplayResult.withId(id: String) = if (id == this.id) this else object : DisplayResult {
     override fun toJson(additionalMetadata: JsonObject, overrideId: String?) = this@withId.toJson(additionalMetadata, overrideId ?: id)
     override val id = id
 }

--- a/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/ScriptTemplateWithDisplayHelpers.kt
+++ b/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/ScriptTemplateWithDisplayHelpers.kt
@@ -14,7 +14,7 @@ abstract class ScriptTemplateWithDisplayHelpers(
 
     val notebook get() = userHandlesProvider.notebook
 
-    fun DISPLAY(value: Any) = host.display(value)
+    fun DISPLAY(value: Any, id: String? = null) = host.display(value, id)
 
     fun UPDATE_DISPLAY(value: Any, id: String?) = host.updateDisplay(value, id)
 

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/apiImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/apiImpl.kt
@@ -66,8 +66,10 @@ class DisplayContainerImpl : MutableDisplayContainer {
     private val displays: MutableMap<String?, MutableList<DisplayResultWrapper>> = mutableMapOf()
 
     override fun add(display: DisplayResultWrapper) {
-        val list = displays.getOrPut(display.id) { mutableListOf() }
-        list.add(display)
+        synchronized(displays) {
+            val list = displays.getOrPut(display.id) { mutableListOf() }
+            list.add(display)
+        }
     }
 
     override fun add(display: DisplayResult, cell: MutableCodeCell) {
@@ -75,18 +77,24 @@ class DisplayContainerImpl : MutableDisplayContainer {
     }
 
     override fun getAll(): List<DisplayResultWithCell> {
-        return displays.flatMap { it.value }
+        synchronized(displays) {
+            return displays.flatMap { it.value }
+        }
     }
 
     override fun getById(id: String?): List<DisplayResultWithCell> {
-        return displays[id].orEmpty()
+        synchronized(displays) {
+            return displays[id].orEmpty()
+        }
     }
 
     override fun update(id: String?, display: DisplayResult) {
-        val initialDisplays = displays[id] ?: return
-        val updated = initialDisplays.map { DisplayResultWrapper.create(display, it.cell) }
-        initialDisplays.clear()
-        initialDisplays.addAll(updated)
+        synchronized(displays) {
+            val initialDisplays = displays[id] ?: return
+            val updated = initialDisplays.map { DisplayResultWrapper.create(display, it.cell) }
+            initialDisplays.clear()
+            initialDisplays.addAll(updated)
+        }
     }
 }
 

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/connection.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/connection.kt
@@ -48,7 +48,7 @@ class JupyterConnectionImpl(
         private fun getInput(): String {
             stdin.sendMessage(
                 makeReplyMessage(
-                    contextMessage,
+                    contextMessage!!,
                     MessageType.INPUT_REQUEST,
                     content = InputRequest("stdin:")
                 )
@@ -156,7 +156,7 @@ class JupyterConnectionImpl(
     override fun setContextMessage(message: RawMessage?) {
         _contextMessage = message
     }
-    override val contextMessage: RawMessage get() = _contextMessage!!
+    override val contextMessage: RawMessage? get() = _contextMessage
 
     override val executor: JupyterExecutor = JupyterExecutorImpl()
 

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/JupyterConnectionInternal.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/JupyterConnectionInternal.kt
@@ -9,7 +9,7 @@ import java.io.InputStream
 
 interface JupyterConnectionInternal : JupyterConnection {
     val config: KernelConfig
-    val contextMessage: RawMessage
+    val contextMessage: RawMessage?
 
     val heartbeat: JupyterSocket
     val shell: JupyterSocket

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlinx.jupyter.api.libraries.RawMessage
 import org.jetbrains.kotlinx.jupyter.api.libraries.portField
 import org.jetbrains.kotlinx.jupyter.api.setDisplayId
 import org.jetbrains.kotlinx.jupyter.api.textResult
+import org.jetbrains.kotlinx.jupyter.api.withId
 import org.jetbrains.kotlinx.jupyter.common.looksLikeReplCommand
 import org.jetbrains.kotlinx.jupyter.compiler.util.EvaluatedSnippetMetadata
 import org.jetbrains.kotlinx.jupyter.config.KernelStreams
@@ -118,12 +119,12 @@ class OkResponseWithMessage(
 }
 
 interface DisplayHandler {
-    fun handleDisplay(value: Any, host: ExecutionHost)
+    fun handleDisplay(value: Any, host: ExecutionHost, id: String? = null)
     fun handleUpdate(value: Any, host: ExecutionHost, id: String? = null)
 }
 
 object NoOpDisplayHandler : DisplayHandler {
-    override fun handleDisplay(value: Any, host: ExecutionHost) {
+    override fun handleDisplay(value: Any, host: ExecutionHost, id: String?) {
     }
 
     override fun handleUpdate(value: Any, host: ExecutionHost, id: String?) {
@@ -141,8 +142,8 @@ class SocketDisplayHandler(
         return renderedValue.toDisplayResult(notebook)
     }
 
-    override fun handleDisplay(value: Any, host: ExecutionHost) {
-        val display = render(host, value) ?: return
+    override fun handleDisplay(value: Any, host: ExecutionHost, id: String?) {
+        val display = render(host, value)?.let { if(id != null) it.withId(id) else it } ?: return
         val json = display.toJson()
 
         notebook.currentCell?.addDisplay(display)

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
@@ -143,7 +143,7 @@ class SocketDisplayHandler(
     }
 
     override fun handleDisplay(value: Any, host: ExecutionHost, id: String?) {
-        val display = render(host, value)?.let { if(id != null) it.withId(id) else it } ?: return
+        val display = render(host, value)?.let { if (id != null) it.withId(id) else it } ?: return
         val json = display.toJson()
 
         notebook.currentCell?.addDisplay(display)

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/protocol.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlinx.jupyter.EvalRequestData
 import org.jetbrains.kotlinx.jupyter.ExecutionResult
 import org.jetbrains.kotlinx.jupyter.LoggingManagement.disableLogging
 import org.jetbrains.kotlinx.jupyter.LoggingManagement.mainLoggerLevel
-import org.jetbrains.kotlinx.jupyter.MutableDisplayContainer
 import org.jetbrains.kotlinx.jupyter.MutableNotebook
 import org.jetbrains.kotlinx.jupyter.OutputConfig
 import org.jetbrains.kotlinx.jupyter.ReplForJupyter
@@ -64,10 +63,10 @@ abstract class Response(
     abstract val state: ResponseState
 
     fun send(connection: JupyterConnectionInternal, requestCount: Long, requestMsg: RawMessage, startedTime: String) {
-        if (stdOut != null && stdOut.isNotEmpty()) {
+        if (!stdOut.isNullOrEmpty()) {
             connection.sendOut(requestMsg, JupyterOutType.STDOUT, stdOut)
         }
-        if (stdErr != null && stdErr.isNotEmpty()) {
+        if (!stdErr.isNullOrEmpty()) {
             connection.sendOut(requestMsg, JupyterOutType.STDERR, stdErr)
         }
         sendBody(connection, requestCount, requestMsg, startedTime)
@@ -165,7 +164,7 @@ class SocketDisplayHandler(
         val container = notebook.displays
         container.update(id, display)
         container.getById(id).distinctBy { it.cell.id }.forEach {
-            (it.cell.displays as MutableDisplayContainer).update(id, display)
+            it.cell.displays.update(id, display)
         }
 
         json.setDisplayId(id) ?: throw RuntimeException("`update_display_data` response should provide an id of data being updated")

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/CellExecutorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/impl/CellExecutorImpl.kt
@@ -210,8 +210,8 @@ internal class CellExecutorImpl(private val replContext: SharedReplContext) : Ce
 
         override fun execute(code: Code) = executor.execute(code, displayHandler, processVariables = false, invokeAfterCallbacks = false, stackFrame = stackFrame).result
 
-        override fun display(value: Any) {
-            displayHandler.handleDisplay(value, this)
+        override fun display(value: Any, id: String?) {
+            displayHandler.handleDisplay(value, this, id)
         }
 
         override fun updateDisplay(value: Any, id: String?) {

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/testUtil.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/testUtil.kt
@@ -153,7 +153,7 @@ class InMemoryLibraryResolver(
 }
 
 class TestDisplayHandler(val list: MutableList<Any> = mutableListOf()) : DisplayHandler {
-    override fun handleDisplay(value: Any, host: ExecutionHost) {
+    override fun handleDisplay(value: Any, host: ExecutionHost, id: String?) {
         list.add(value)
     }
 


### PR DESCRIPTION
* Add nullable `id` argument to `ScriptTemplateWithDisplayHelpers.DISPLAY` and `KotlinKernelHost.display` methods in kernel API.
* Add `overrideId` argument to `DisplayResult.toJson` method