### PR TITLE
Fix race condition in `DisplayContainerImpl.displays` list.

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/apiImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/apiImpl.kt
@@ -94,7 +94,7 @@ class DisplayContainerImpl : MutableDisplayContainer {
 
     override fun getById(id: String?): List<MutableDisplayResultWithCell> {
         synchronized(displays) {
-            return displays[id].orEmpty()
+            return displays[id]?.toList().orEmpty()
         }
     }
 


### PR DESCRIPTION
Fix concurrent read/write in a list of displays.