### PR TITLE
Moved cache in message_type serializer to ConcurrentHashMap

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message_types.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message_types.kt
@@ -29,10 +29,10 @@ import org.jetbrains.kotlinx.jupyter.config.LanguageInfo
 import org.jetbrains.kotlinx.jupyter.exceptions.ReplException
 import org.jetbrains.kotlinx.jupyter.protocol.messageDataJson
 import org.jetbrains.kotlinx.jupyter.util.EMPTY
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 import kotlin.script.experimental.api.ScriptDiagnostic
-import java.util.concurrent.ConcurrentHashMap
 
 @Serializable(MessageTypeSerializer::class)
 enum class MessageType(val contentClass: KClass<out MessageContent>) {

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message_types.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message_types.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlinx.jupyter.util.EMPTY
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 import kotlin.script.experimental.api.ScriptDiagnostic
+import java.util.concurrent.ConcurrentHashMap
 
 @Serializable(MessageTypeSerializer::class)
 enum class MessageType(val contentClass: KClass<out MessageContent>) {
@@ -143,7 +144,7 @@ enum class KernelStatus {
 }
 
 object MessageTypeSerializer : KSerializer<MessageType> {
-    private val cache: MutableMap<String, MessageType> = hashMapOf()
+    private val cache: MutableMap<String, MessageType> = ConcurrentHashMap()
 
     private fun getMessageType(type: String): MessageType {
         return cache.computeIfAbsent(type) { newType ->
@@ -168,7 +169,7 @@ object MessageTypeSerializer : KSerializer<MessageType> {
 }
 
 object DetailsLevelSerializer : KSerializer<DetailLevel> {
-    private val cache: MutableMap<Int, DetailLevel> = hashMapOf()
+    private val cache: MutableMap<Int, DetailLevel> = ConcurrentHashMap()
 
     private fun getDetailsLevel(type: Int): DetailLevel {
         return cache.computeIfAbsent(type) { newLevel ->


### PR DESCRIPTION
Moved cache in message_type serializer to ConcurrentHashMap to avoid concurrent modification exceptions. ConcurrentHashMap seems a good fit due to low overhead when reading from the map (which is the main purpose of a cache).

Updated both MessageTypeSerializer and DetailsLevelSerializer.