### PR TITLE
Add API for handling result field with a type converter API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -360,6 +360,7 @@ Other options are resolving library descriptor from a local file or from remote 
 ```
 
 #### List of supported libraries:
+ - [2p-kt](https://github.com/gciatto/kt-math) - Kotlin Multi-Platform ecosystem for symbolic AI
  - [biokotlin](https://github.com/maize-genetics/BioKotlin) - BioKotlin aims to be a high-performance bioinformatics library that brings the power and speed of compiled programming languages to scripting and big data environments.
  - [combinatoricskt](https://github.com/shiguruikai/combinatoricskt) - A combinatorics library for Kotlin
  - [coroutines](https://github.com/Kotlin/kotlinx.coroutines) - Asynchronous programming and reactive streams support
@@ -385,6 +386,7 @@ Other options are resolving library descriptor from a local file or from remote 
  - [krangl](https://github.com/holgerbrandl/krangl) - Kotlin DSL for data wrangling
  - [kraphviz](https://github.com/nidi3/graphviz-java) - Graphviz wrapper for JVM
  - [kravis](https://github.com/holgerbrandl/kravis) - Kotlin grammar for data visualization
+ - [kt-math](https://github.com/gciatto/kt-math) - Kotlin multi-platform port of java.math.*
  - [lets-plot](https://github.com/JetBrains/lets-plot-kotlin) - ggplot-like interactive visualization for Kotlin
  - [lets-plot-dataframe](https://github.com/JetBrains/lets-plot-kotlin) - A bridge between Lets-Plot and dataframe libraries
  - [lets-plot-gt](https://github.com/JetBrains/lets-plot-kotlin) - Lets-Plot visualisation for GeoTools toolkit

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/fieldsHandlingEx.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/fieldsHandlingEx.kt
@@ -1,0 +1,66 @@
+package org.jetbrains.kotlinx.jupyter.api
+
+import java.lang.reflect.Field
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.javaField
+
+class FieldInfo(
+    val kotlinProperty: KProperty<*>?,
+    val javaField: Field,
+)
+
+val FieldInfo.name: VariableName get() = kotlinProperty?.name ?: javaField.name
+val FieldInfo.isCellResult: Boolean get() = kotlinProperty == null && name.startsWith("res")
+
+private fun KProperty<*>.toFieldInfo() = FieldInfo(this, javaField ?: throw IllegalArgumentException("Property $this should have backing field"))
+
+fun interface FieldHandlerExecutionEx<T> : FieldHandlerExecution<T> {
+    fun execute(host: KotlinKernelHost, value: T, fieldInfo: FieldInfo): FieldValue?
+
+    override fun execute(host: KotlinKernelHost, value: T, property: KProperty<*>) {
+        execute(host, value, property.toFieldInfo())
+    }
+}
+
+interface FieldHandlerEx : FieldHandler {
+    /**
+     * Tells if this handler accepts the given property
+     * Called for each variable in the cells executed by users,
+     * except those names are starting from [TEMP_PROPERTY_PREFIX]
+     * or those that have been already consumed by another handler
+     *
+     * @param value Property value
+     * @param fieldInfo Property runtime information
+     */
+    fun accepts(value: Any?, fieldInfo: FieldInfo): Boolean
+
+    override fun accepts(value: Any?, property: KProperty<*>): Boolean {
+        return accepts(value, property.toFieldInfo())
+    }
+
+    /**
+     * Execution to handle conversion.
+     * Should not throw if [accepts] returns true
+     * Called for each property for which [accepts] returned true
+     */
+    override val execution: FieldHandlerExecutionEx<*>
+}
+
+class ResultFieldUpdateHandler(
+    val updateCondition: (value: Any?, field: Field) -> Boolean,
+    updateAction: (host: KotlinKernelHost, value: Any?, field: Field) -> VariableName?,
+) : FieldHandlerEx {
+    override val execution: FieldHandlerExecutionEx<Any?> = FieldHandlerExecutionEx { host, value, fieldInfo ->
+        val field = fieldInfo.javaField
+        val tempField = updateAction(host, value, field)
+        if (tempField != null) {
+            val fieldName = field.name
+            host.execute("val $fieldName = $tempField; $fieldName")
+        } else null
+    }
+
+    override fun accepts(value: Any?, fieldInfo: FieldInfo): Boolean {
+        if (!fieldInfo.isCellResult) return false
+        return updateCondition(value, fieldInfo.javaField)
+    }
+}

--- a/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/context.kt
+++ b/jupyter-lib/lib/src/main/kotlin/jupyter/kotlin/context.kt
@@ -1,5 +1,6 @@
 package jupyter.kotlin
 
+import java.lang.reflect.Field
 import java.util.HashMap
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
@@ -74,15 +75,12 @@ class KotlinFunctionInfo(val function: KFunction<*>, val line: Any) : Comparable
     }
 }
 
-class KotlinVariableInfo(val value: Any?, val descriptor: KProperty<*>, val line: Any) {
-
-    val name: String
-        get() = descriptor.name
-
-    @Suppress("MemberVisibilityCanBePrivate")
-    val type: String
-        get() = descriptor.returnType.toString()
-
+class KotlinVariableInfo(
+    val value: Any?,
+    val kotlinProperty: KProperty<*>?,
+    val javaField: Field,
+    val line: Any,
+) {
     fun toString(shortenTypes: Boolean): String {
         var type: String = type
         if (shortenTypes) {
@@ -95,3 +93,10 @@ class KotlinVariableInfo(val value: Any?, val descriptor: KProperty<*>, val line
         return toString(false)
     }
 }
+
+val KotlinVariableInfo.name: String
+    get() = kotlinProperty?.name ?: javaField.name
+
+@Suppress("MemberVisibilityCanBePrivate")
+val KotlinVariableInfo.type: String
+    get() = kotlinProperty?.returnType?.toString() ?: javaField.genericType.typeName

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/FieldsProcessorInternal.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/FieldsProcessorInternal.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlinx.jupyter.codegen
 
+import org.jetbrains.kotlinx.jupyter.api.FieldValue
 import org.jetbrains.kotlinx.jupyter.api.FieldsProcessor
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 
@@ -11,5 +12,5 @@ interface FieldsProcessorInternal : FieldsProcessor {
     /**
      * Processes local variables and generates code snippets that perform type conversions
      */
-    fun process(host: KotlinKernelHost)
+    fun process(host: KotlinKernelHost): FieldValue?
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/FieldsProcessorImpl.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/codegen/FieldsProcessorImpl.kt
@@ -1,8 +1,13 @@
 package org.jetbrains.kotlinx.jupyter.codegen
 
+import jupyter.kotlin.name
 import org.jetbrains.kotlinx.jupyter.api.FieldHandler
+import org.jetbrains.kotlinx.jupyter.api.FieldHandlerEx
 import org.jetbrains.kotlinx.jupyter.api.FieldHandlerExecution
+import org.jetbrains.kotlinx.jupyter.api.FieldHandlerExecutionEx
 import org.jetbrains.kotlinx.jupyter.api.FieldHandlerWithPriority
+import org.jetbrains.kotlinx.jupyter.api.FieldInfo
+import org.jetbrains.kotlinx.jupyter.api.FieldValue
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelHost
 import org.jetbrains.kotlinx.jupyter.api.TEMP_PROPERTY_PREFIX
 import org.jetbrains.kotlinx.jupyter.exceptions.LibraryProblemPart
@@ -19,23 +24,32 @@ class FieldsProcessorImpl(
         return extensions.elementsWithPriority().map { FieldHandlerWithPriority(it.first, it.second) }
     }
 
-    override fun process(host: KotlinKernelHost) {
+    override fun process(host: KotlinKernelHost): FieldValue? {
         val fieldHandlers = mutableSetOf<FieldHandler>()
         val exceptions = mutableListOf<Throwable>()
+        var newResultField: FieldValue? = null
         val variableInfos = contextUpdater.context.currentVariables.values.filter {
             !it.name.startsWith(TEMP_PROPERTY_PREFIX)
         }
 
         for (info in variableInfos) {
-            val property = info.descriptor
-            property.isAccessible = true
             val value = info.value ?: continue
-            val handler = extensions.firstOrNull { it.accepts(value, property) }
+
+            info.kotlinProperty?.isAccessible = true
+            info.javaField.isAccessible = true
+            val fieldInfo = FieldInfo(info.kotlinProperty, info.javaField)
+
+            val handler = extensions.firstOrNull { it.acceptsEx(value, fieldInfo) }
             if (handler != null) {
                 @Suppress("UNCHECKED_CAST")
                 val execution = handler.execution as FieldHandlerExecution<Any>
                 try {
-                    execution.execute(host, value, property)
+                    execution.executeEx(host, value, fieldInfo)?.let { result ->
+                        if (newResultField == null) {
+                            newResultField = result
+                        }
+                    }
+
                     fieldHandlers.add(handler)
                 } catch (e: Throwable) {
                     exceptions.add(e)
@@ -52,5 +66,26 @@ class FieldsProcessorImpl(
         }
 
         exceptions.throwLibraryException(LibraryProblemPart.CONVERTERS)
+
+        return newResultField
+    }
+}
+
+private fun FieldHandler.acceptsEx(value: Any?, fieldInfo: FieldInfo): Boolean {
+    return if (this is FieldHandlerEx) {
+        this.accepts(value, fieldInfo)
+    } else {
+        val property = fieldInfo.kotlinProperty ?: return false
+        accepts(value, property)
+    }
+}
+
+private fun <T> FieldHandlerExecution<T>.executeEx(host: KotlinKernelHost, value: T, fieldInfo: FieldInfo): FieldValue? {
+    return if (this is FieldHandlerExecutionEx<T>) {
+        this.execute(host, value, fieldInfo)
+    } else {
+        val property = fieldInfo.kotlinProperty ?: return null
+        execute(host, value, property)
+        null
     }
 }

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/ContextUpdater.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/repl/ContextUpdater.kt
@@ -73,10 +73,7 @@ class ContextUpdater(val context: KotlinContext, private val evaluator: BasicJvm
 
             field.isAccessible = true
             val value = field.get(o)
-            val descriptor = field.kotlinProperty
-            if (descriptor != null) {
-                context.addVariable(fieldName, KotlinVariableInfo(value, descriptor, o))
-            }
+            context.addVariable(fieldName, KotlinVariableInfo(value, field.kotlinProperty, field, o))
         }
     }
 

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/CustomLibraryResolverTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/CustomLibraryResolverTests.kt
@@ -7,16 +7,13 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import jupyter.kotlin.receivers.TempAnnotation
 import jupyter.kotlin.variablesReport
 import kotlinx.serialization.SerializationException
-import org.jetbrains.kotlinx.jupyter.ReplForJupyter
 import org.jetbrains.kotlinx.jupyter.api.DisplayResult
 import org.jetbrains.kotlinx.jupyter.api.KotlinKernelVersion.Companion.toMaybeUnspecifiedString
 import org.jetbrains.kotlinx.jupyter.api.MimeTypedResult
 import org.jetbrains.kotlinx.jupyter.api.MimeTypes
 import org.jetbrains.kotlinx.jupyter.api.VariableDeclaration
 import org.jetbrains.kotlinx.jupyter.api.declare
-import org.jetbrains.kotlinx.jupyter.api.libraries.LibraryDefinition
 import org.jetbrains.kotlinx.jupyter.api.libraries.ResourceType
-import org.jetbrains.kotlinx.jupyter.api.libraries.Variable
 import org.jetbrains.kotlinx.jupyter.api.textResult
 import org.jetbrains.kotlinx.jupyter.defaultRuntimeProperties
 import org.jetbrains.kotlinx.jupyter.exceptions.LibraryProblemPart
@@ -24,13 +21,10 @@ import org.jetbrains.kotlinx.jupyter.exceptions.ReplEvalRuntimeException
 import org.jetbrains.kotlinx.jupyter.exceptions.ReplException
 import org.jetbrains.kotlinx.jupyter.exceptions.ReplLibraryException
 import org.jetbrains.kotlinx.jupyter.exceptions.ReplPreprocessingException
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryResolver
 import org.jetbrains.kotlinx.jupyter.libraries.parseLibraryDescriptor
-import org.jetbrains.kotlinx.jupyter.repl.creating.createRepl
 import org.jetbrains.kotlinx.jupyter.test.evalRaw
 import org.jetbrains.kotlinx.jupyter.test.evalRendered
 import org.jetbrains.kotlinx.jupyter.test.library
-import org.jetbrains.kotlinx.jupyter.test.testRepositories
 import org.jetbrains.kotlinx.jupyter.test.toLibraries
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -43,24 +37,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CustomLibraryResolverTests : AbstractReplTest() {
-
-    private fun makeRepl(vararg libs: Pair<String, LibraryDefinition>) = makeRepl(libs.toList().toLibraries())
-
-    private fun makeRepl(libraryResolver: LibraryResolver) = createRepl(
-        resolutionInfoProvider,
-        classpathWithTestLib,
-        homeDir,
-        testRepositories,
-        libraryResolver,
-    )
-
-    private fun testOneLibUsage(definition: LibraryDefinition, args: List<Variable> = emptyList()): ReplForJupyter {
-        val repl = makeRepl("mylib" to definition)
-        val paramList = if (args.isEmpty()) ""
-        else args.joinToString(", ", "(", ")") { "${it.name}=${it.value}" }
-        repl.evalRaw("%use mylib$paramList")
-        return repl
-    }
 
     @Test
     fun testUseMagic() {
@@ -123,7 +99,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
 
         val libs = listOf(lib1, lib2, lib3).toLibraries()
 
-        val executor = makeRepl(libs).mockExecution()
+        val executor = makeReplWithLibraries(libs).mockExecution()
 
         executor.execute("%use mylib(1.0), another")
         val executedCodes = executor.executedCodes
@@ -175,7 +151,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
         """.trimIndent()
 
         val libs = listOf(lib1, lib2).toLibraries()
-        val replWithResolver = makeRepl(libs)
+        val replWithResolver = makeReplWithLibraries(libs)
         replWithResolver.evalRaw("%use mylib, mylib2")
         val results = replWithResolver.evalOnShutdown()
 
@@ -197,7 +173,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
         """.trimIndent()
 
         val libs = listOf(lib).toLibraries()
-        val repl = makeRepl(libs)
+        val repl = makeReplWithLibraries(libs)
 
         repl.evalRaw(
             """
@@ -226,7 +202,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
         """.trimIndent()
 
         val libs = listOf(lib1).toLibraries()
-        val replWithResolver = makeRepl(libs)
+        val replWithResolver = makeReplWithLibraries(libs)
         val exception = assertThrows<ReplPreprocessingException> { replWithResolver.evalRaw("%use mylib") }
 
         val message = exception.message!!
@@ -271,7 +247,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
             }
         }
 
-        val repl = makeRepl(lib1, lib2).trackExecution()
+        val repl = makeReplWithLibraries(lib1, lib2).trackExecution()
 
         val code = """
             %use lib1
@@ -313,7 +289,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
                 scheduleExecution("val b = a")
             }
         }
-        val repl = makeRepl(lib).trackExecution()
+        val repl = makeReplWithLibraries(lib).trackExecution()
 
         repl.execute("1")
 
@@ -391,7 +367,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     @Test
     fun testLibraryWithIncorrectImport() {
         val e = assertThrows<ReplLibraryException> {
-            testOneLibUsage(
+            makeReplEnablingSingleLibrary(
                 library {
                     import("ru.incorrect")
                 },
@@ -403,7 +379,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     @Test
     fun testLibraryWithIncorrectDependency() {
         val e = assertThrows<ReplLibraryException> {
-            testOneLibUsage(
+            makeReplEnablingSingleLibrary(
                 library {
                     dependencies("org.foo:bar:42")
                 },
@@ -415,7 +391,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     @Test
     fun testLibraryWithIncorrectInitCode() {
         val e = assertThrows<ReplLibraryException> {
-            testOneLibUsage(
+            makeReplEnablingSingleLibrary(
                 library {
                     onLoaded {
                         null!!
@@ -428,7 +404,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
 
     @Test
     fun testExceptionInRenderer() {
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 render<String> { throw IllegalStateException() }
             },
@@ -447,7 +423,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
 
     @Test
     fun testBeforeExecutionException() {
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 beforeCellExecution {
                     throw NullPointerException()
@@ -465,7 +441,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     fun `multiple before-cell executions should be executed in the order of declaration`() {
         val builder = StringBuilder()
 
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 beforeCellExecution {
                     builder.append("1")
@@ -484,7 +460,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
 
     @Test
     fun testExceptionRendering() {
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 renderThrowable<IllegalArgumentException> { textResult(it.message.orEmpty()) }
             },
@@ -507,47 +483,11 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     }
 
     @Test
-    fun testUpdateVariable() {
-        var listInvocationCounter = 0
-
-        val repl = testOneLibUsage(
-            library {
-                onVariable<Any> { _, prop ->
-                    execute("val gen_${prop.name} = 1")
-                }
-                onVariable<List<Int>> { _, _ ->
-                    ++listInvocationCounter
-                }
-            },
-        )
-
-        repl.evalRaw("val ls = listOf(1, 2)")
-
-        repl.evalRaw(
-            """
-            val (a, b) = 1 to 's'
-            val c = "42"
-            """.trimIndent(),
-        )
-
-        val res = repl.evalRaw(
-            """
-            gen_a + gen_b + gen_c
-            """.trimIndent(),
-        )
-        res shouldBe 3
-
-        // List variables updater should be applied only once
-        // because there is only one declaration of the list variable
-        listInvocationCounter shouldBe 1
-    }
-
-    @Test
     @ExperimentalStdlibApi
     fun testLibraryProperties() {
         val mutProp = arrayListOf(1)
 
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 onLoaded {
                     declare(
@@ -575,7 +515,7 @@ class CustomLibraryResolverTests : AbstractReplTest() {
 
     @Test
     fun testInternalMarkers() {
-        val repl = testOneLibUsage(
+        val repl = makeReplEnablingSingleLibrary(
             library {
                 onLoaded {
                     declare(

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/TypeConverterTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/TypeConverterTests.kt
@@ -1,0 +1,148 @@
+package org.jetbrains.kotlinx.jupyter.test.repl
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import org.jetbrains.kotlinx.jupyter.api.MimeTypedResult
+import org.jetbrains.kotlinx.jupyter.api.MimeTypes
+import org.jetbrains.kotlinx.jupyter.api.ResultFieldUpdateHandler
+import org.jetbrains.kotlinx.jupyter.api.createRenderer
+import org.jetbrains.kotlinx.jupyter.test.evalRaw
+import org.jetbrains.kotlinx.jupyter.test.evalRendered
+import org.jetbrains.kotlinx.jupyter.test.library
+import org.junit.jupiter.api.Test
+
+class TypeConverterTests : AbstractReplTest() {
+    @Test
+    fun `code should be generated and executed for correct variables`() {
+        with(
+            makeReplEnablingSingleLibrary(
+                library {
+                    onVariable<Any> { _, prop ->
+                        execute("val gen_${prop.name} = 1")
+                    }
+                },
+            ),
+        ) {
+            evalRaw(
+                """
+                val (a, b) = 1 to 's'
+                val c = "42"
+                35
+                """.trimIndent(),
+            )
+
+            evalRaw(
+                """
+            gen_a + gen_b + gen_c
+                """.trimIndent(),
+            ) shouldBe 3
+        }
+    }
+
+    @Test
+    fun `code should be generated for particular result fields`() {
+        var resultInvocationCounter = 0
+
+        with(
+            makeReplEnablingSingleLibrary(
+                library {
+                    addTypeConverter(
+                        ResultFieldUpdateHandler(
+                            updateCondition = { value, _ -> value == 35 },
+                            updateAction = { _, _, _ -> ++resultInvocationCounter; null },
+                        ),
+                    )
+                },
+            ),
+        ) {
+            evalRaw(
+                """
+                val t = 35
+                val b = t
+                35
+                """.trimIndent(),
+            )
+
+            resultInvocationCounter shouldBe 1
+        }
+    }
+
+    @Test
+    fun `type converter should be only applied once for each property (and not more than one at a time)`() {
+        var counter1 = 0
+        var counter2 = 0
+
+        with(
+            makeReplEnablingSingleLibrary(
+                library {
+                    onVariable<List<Int>> { _, _ ->
+                        ++counter1
+                    }
+                    onVariable<List<Int>> { _, _ ->
+                        ++counter2
+                    }
+                },
+            ),
+        ) {
+            evalRaw("val ls = listOf(1, 2)")
+            evalRaw("ls") // result field shouldn't be considered with this type of converters
+            evalRaw("val ls2 = ls")
+
+            counter1 shouldBe 0
+            counter2 shouldBe 2 // type converted that was added later has higher priority
+        }
+    }
+
+    @Test
+    fun `result field created by type converter should be rendered correctly`() {
+        with(
+            makeReplEnablingSingleLibrary(
+                library {
+                    val wrapperClassName = "ResultWrapper"
+
+                    // Define the class that can wrap integers
+                    onLoaded { execute("class $wrapperClassName(val x: Int)") }
+
+                    // Add type converter only for results of Int type, and only for even numbers
+                    // This type converter wraps these numbers to the wrapper we defined above
+                    addTypeConverter(
+                        ResultFieldUpdateHandler(
+                            updateCondition = { value, _ -> (value as? Int)?.let { value % 2 == 0 } ?: false },
+                            updateAction = { host, _, field -> host.execute("$wrapperClassName(${field.name})").name },
+                        ),
+                    )
+
+                    // Add renderer for the instances of the wrapper class that renders them to HTML
+                    addRenderer(
+                        createRenderer(
+                            renderCondition = { it.value?.let { v -> v::class.simpleName == wrapperClassName } ?: false },
+                            renderAction = { host, fieldValue ->
+                                host.execute("(${fieldValue.name} as $wrapperClassName).x.let {v -> HTML(\"<b>\${v * 2}</b>\")}").value
+                            },
+                        ),
+                    )
+                },
+            ),
+        ) {
+            evalRendered(
+                """
+                val a = 22
+                32
+                """.trimIndent(),
+            ).let { renderedResult ->
+                renderedResult.shouldBeTypeOf<MimeTypedResult>()
+                renderedResult[MimeTypes.HTML] shouldBe "<b>64</b>"
+            }
+
+            evalRendered(
+                """
+                val a = 22
+                33
+                """.trimIndent(),
+            ).let { renderedResult ->
+                renderedResult.shouldBeTypeOf<Int>()
+                renderedResult shouldBe 33
+            }
+        }
+    }
+}


### PR DESCRIPTION
Result field doesn't have Kotlin property representation. To handle it, information about corresponding Java field was added to the low-level API. So, low-level API is broken, but seemingly no one uses it. High-level API was left semantically unchanged (it still doesn't process java fields without corresponding Kotlin properties). `ResultFieldUpdateHandler` class was added to handle this particular use case.