### PR TITLE
KTNB-284 Add support for passing in-memory values as display data or execution results

### DIFF
--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/connection.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/connection.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.kotlinx.jupyter.api.InMemoryResult
 import org.jetbrains.kotlinx.jupyter.util.EMPTY
 import java.util.*
 
@@ -38,6 +39,9 @@ interface RawMessage {
     val parentHeader: JsonObject?
     val metadata: JsonObject?
     val content: JsonElement
+    // For a kernel in embedded mode, sometimes it can be faster to just send a reference to the
+    // in-memory data instead of serializing/deserializing the data.
+    val inMemoryResult: InMemoryResult?
 }
 
 val RawMessage.type: String?

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/swingRendering.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/swingRendering.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.kotlinx.jupyter.api
+
+import java.awt.*
+import java.awt.image.BufferedImage
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+fun JFrame.takeScreenshot(): BufferedImage {
+    // Ensure the frame is fully rendered before taking the screenshot
+    try {
+        SwingUtilities.invokeAndWait { repaint() }
+    } catch (ignore: Exception) { }
+
+    // For retina displays, pick the high-resolution image and downscale it again for a better
+    // screenshot. This is only possible on Java 9+, so for other versions, just do a basic
+    // screen capture.
+    val java9OrLater = !System.getProperty("java.version").startsWith("1.")
+    val captureRect = Rectangle(bounds.x, bounds.y, bounds.width, bounds.height)
+    return if (java9OrLater) {
+        @Suppress("Since15")
+        val results = Robot().createMultiResolutionScreenCapture(captureRect)
+        // Do not down-scale high-resolution screenshots
+        @Suppress("Since15")
+        return results.resolutionVariants.last().asBufferedImage(1.0)
+    } else {
+        Robot().createScreenCapture(captureRect)
+    }
+}
+
+fun JPanel.takeScreenshot(): BufferedImage {
+    // Ensure the frame is fully rendered before taking the screenshot
+    try {
+        SwingUtilities.invokeAndWait { repaint() }
+    } catch (ignore: Exception) { }
+    val config: GraphicsConfiguration? = graphicsConfiguration
+    val scaleFactor: Double = config?.defaultTransform?.scaleX ?: 1.0
+    val image = BufferedImage((width * scaleFactor).toInt(), (height * scaleFactor).toInt(), BufferedImage.TYPE_INT_RGB)
+    with(image.createGraphics()) {
+        scale(scaleFactor, scaleFactor)
+        paint(this)
+        dispose()
+    }
+    return image
+}
+
+fun Image.asBufferedImage(scale: Double = 1.0): BufferedImage {
+    val bufferedImage = BufferedImage(
+        (getWidth(null) * scale).toInt(),
+        (getHeight(null) * scale).toInt(),
+        BufferedImage.TYPE_INT_ARGB
+    )
+    with(bufferedImage.createGraphics()) {
+        setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+        setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+        setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        scale(scale, scale)
+        drawImage(this@asBufferedImage, 0, 0, null)
+        dispose()
+    }
+    return bufferedImage
+}

--- a/jupyter-lib/api/src/test/kotlin/org/jetbrains/kotlinx/jupyter/api/test/InMemoryTest.kt
+++ b/jupyter-lib/api/src/test/kotlin/org/jetbrains/kotlinx/jupyter/api/test/InMemoryTest.kt
@@ -1,0 +1,34 @@
+package org.jetbrains.kotlinx.jupyter.api.test
+
+import org.jetbrains.kotlinx.jupyter.api.takeScreenshot
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.Dimension
+import javax.swing.JButton
+import javax.swing.JFrame
+import javax.swing.JPanel
+import kotlin.test.assertNotNull
+
+class InMemoryTest {
+
+    @Test
+    fun testScreenshotOfJFrame() {
+        val frame = JFrame("Color Changer")
+        frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE
+        frame.preferredSize = Dimension(300, 200)
+        val panel = JPanel()
+        val button1 = JButton("Button 1")
+        val button2 = JButton("Button 2")
+        val button3 = JButton("Button 3")
+        button1.addActionListener { panel.background = Color.RED }
+        button2.addActionListener { panel.background = Color.GREEN }
+        button3.addActionListener { panel.background = Color.BLUE }
+        panel.add(button1)
+        panel.add(button2)
+        panel.add(button3)
+        frame.add(panel)
+        frame.pack()
+        val screenshot = panel.takeScreenshot()
+        assertNotNull(screenshot)
+    }
+}

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/JupyterResponse.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/JupyterResponse.kt
@@ -86,6 +86,7 @@ fun JupyterCommunicationFacility.sendExecuteResult(
                 executionCount = requestCount,
                 data = resultJson["data"]!!,
                 metadata = resultJson["metadata"]!!,
+                inMemoryOutput = result.inMemoryOutput
             ),
         ),
     )

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/SocketDisplayHandler.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/SocketDisplayHandler.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.jupyter.messaging
 
 import kotlinx.serialization.json.Json
+import org.jetbrains.kotlinx.jupyter.api.InMemoryMimeTypedResult
 import org.jetbrains.kotlinx.jupyter.api.libraries.ExecutionHost
 import org.jetbrains.kotlinx.jupyter.api.setDisplayId
 import org.jetbrains.kotlinx.jupyter.api.withId
@@ -30,6 +31,11 @@ class SocketDisplayHandler(
             json["data"],
             json["metadata"],
             json["transient"],
+            if (display is InMemoryMimeTypedResult) {
+                display.inMemoryOutput
+            } else {
+                null
+            }
         )
         sendMessage(MessageType.DISPLAY_DATA, content)
     }
@@ -51,6 +57,11 @@ class SocketDisplayHandler(
             json["data"],
             json["metadata"],
             json["transient"],
+            if (display is InMemoryMimeTypedResult) {
+                display.inMemoryOutput
+            } else {
+                null
+            }
         )
         sendMessage(MessageType.UPDATE_DISPLAY_DATA, content)
     }

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/messaging/message.kt
@@ -42,6 +42,7 @@ fun Message.toRawMessage(): RawMessage {
         dataJson["parent_header"] as? JsonObject,
         dataJson["metadata"] as? JsonObject,
         dataJson["content"]!!,
+        data.inMemoryOutput
     )
 }
 

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/protocol/RawMessageImpl.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/protocol/RawMessageImpl.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import org.jetbrains.kotlinx.jupyter.api.InMemoryResult
 import org.jetbrains.kotlinx.jupyter.api.libraries.RawMessage
 
 data class RawMessageImpl(
@@ -13,6 +14,7 @@ data class RawMessageImpl(
     override val parentHeader: JsonObject?,
     override val metadata: JsonObject?,
     override val content: JsonElement,
+    override val inMemoryResult: InMemoryResult?
 ) : RawMessage {
     override fun toString(): String =
         "msg[${id.joinToString { it.toString(charset = Charsets.UTF_8) }}] $data"

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/protocol/SocketWrapper.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/protocol/SocketWrapper.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlinx.jupyter.protocol
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -129,6 +128,7 @@ class SocketWrapper(
             parentHeader.parseJson()?.jsonObject,
             metadata.parseJson()?.jsonObject,
             content.parseJson().orEmptyObject(),
+            null // In-memory results are never sent from the client to the kernel. Only the other way.
         )
     }
 

--- a/src/main/kotlin/org/jetbrains/kotlinx/jupyter/util.kt
+++ b/src/main/kotlin/org/jetbrains/kotlinx/jupyter/util.kt
@@ -4,26 +4,21 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import org.jetbrains.kotlinx.jupyter.api.arrayRenderer
 import org.jetbrains.kotlinx.jupyter.api.bufferedImageRenderer
+ import org.jetbrains.kotlinx.jupyter.api.swingJFrameInMemoryRenderer
+import org.jetbrains.kotlinx.jupyter.api.swingJPanelInMemoryRenderer
 import org.jetbrains.kotlinx.jupyter.codegen.ResultsRenderersProcessor
 import org.jetbrains.kotlinx.jupyter.common.LibraryDescriptorsManager
 import org.jetbrains.kotlinx.jupyter.compiler.util.CodeInterval
 import org.jetbrains.kotlinx.jupyter.compiler.util.SourceCodeImpl
 import org.jetbrains.kotlinx.jupyter.config.catchAll
-import org.jetbrains.kotlinx.jupyter.libraries.DefaultLibraryDescriptorGlobalOptions
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryDescriptor
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryDescriptorGlobalOptions
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryDescriptorsProvider
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryReferenceParser
-import org.jetbrains.kotlinx.jupyter.libraries.LibraryResolver
-import org.jetbrains.kotlinx.jupyter.libraries.ResourceLibraryDescriptorsProvider
-import org.jetbrains.kotlinx.jupyter.libraries.parseLibraryDescriptor
-import org.jetbrains.kotlinx.jupyter.libraries.parseLibraryDescriptorGlobalOptions
+import org.jetbrains.kotlinx.jupyter.libraries.*
 import org.jetbrains.kotlinx.jupyter.util.createCachedFun
 import java.io.Closeable
 import java.io.File
 import kotlin.script.experimental.api.ScriptDiagnostic
 import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.jvm.util.toSourceCodePosition
+
 
 fun List<String>.joinToLines() = joinToString("\n")
 
@@ -61,6 +56,8 @@ fun withPath(path: String?, diagnostics: List<ScriptDiagnostic>): List<ScriptDia
 fun ResultsRenderersProcessor.registerDefaultRenderers() {
     register(bufferedImageRenderer)
     register(arrayRenderer)
+    register(swingJFrameInMemoryRenderer)
+    register(swingJPanelInMemoryRenderer)
 }
 
 /**

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/embeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/embeddingTest.kt
@@ -1,17 +1,10 @@
 package org.jetbrains.kotlinx.jupyter.test
 
-import org.jetbrains.kotlinx.jupyter.api.MimeTypedResult
-import org.jetbrains.kotlinx.jupyter.api.MimeTypes
-import org.jetbrains.kotlinx.jupyter.api.ResultHandlerCodeExecution
-import org.jetbrains.kotlinx.jupyter.api.SubtypeRendererTypeHandler
-import org.jetbrains.kotlinx.jupyter.api.libraries.LibraryResource
-import org.jetbrains.kotlinx.jupyter.api.libraries.ResourceFallbacksBundle
-import org.jetbrains.kotlinx.jupyter.api.libraries.ResourceLocation
-import org.jetbrains.kotlinx.jupyter.api.libraries.ResourcePathType
-import org.jetbrains.kotlinx.jupyter.api.libraries.ResourceType
-import org.jetbrains.kotlinx.jupyter.api.libraries.libraryDefinition
+import org.jetbrains.kotlinx.jupyter.api.*
+import org.jetbrains.kotlinx.jupyter.api.libraries.*
 import org.jetbrains.kotlinx.jupyter.test.repl.AbstractSingleReplTest
 import org.junit.jupiter.api.Test
+import javax.swing.JFrame
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -122,6 +115,22 @@ class EmbedReplTest : AbstractSingleReplTest() {
             """.trimIndent(),
         )
         assertEquals("[12, 13, 14]", result2.renderedValue)
+    }
+
+    @Test
+    fun testInMemoryCellValues() {
+        val code = """
+            import javax.swing.JFrame
+            val frame = JFrame("panel")
+            frame.setSize(300, 300)
+            frame
+        """.trimIndent()
+        val result  = eval(code)
+        assertTrue(result.renderedValue is InMemoryMimeTypedResult)
+        assertTrue(result.displayValue is InMemoryMimeTypedResult)
+        val display = result.displayValue as InMemoryMimeTypedResult
+        assertTrue(display.inMemoryOutput.result is JFrame)
+        assertEquals(InMemoryMimeTypes.SWING, display.inMemoryOutput.mimeType)
     }
 }
 


### PR DESCRIPTION
This PR is the kernel part of https://youtrack.jetbrains.com/issue/KTNB-284

This PR extends the Jupyter messages being sent from the Server to the Client with a new `inMemoryResult`. This field only makes sense for the embedded kernel used in IntelliJ, as it contains the display result as a pure in-memory object rather than serializing it to JSON.

In-memory results are represented using the `InMemoryMimeTypedResult` display result. This type also contains fallback data that will be used by the front-end when the in-memory result isn't available, like when saving a file to disk. Currently, the fallback data is a screenshot of the UI.

In terms of public user facing API's. This PR also introduces a new helper method called `SWING()` which can be used in combination with the `DISPLAY` helper function.

Usages:

```
// Cell 1: 
import java.awt.Color
import java.awt.Dimension
import java.io.File
import javax.swing.JButton
import javax.swing.JFrame
import javax.swing.JPanel

val frame = JFrame("Color Changer")
frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE
frame.preferredSize = Dimension(300, 200)
val panel = JPanel()
panel.preferredSize = Dimension(300, 200)
val button1 = JButton("Button 1")
val button2 = JButton("Button 2")
val button3 = JButton("Button 3")
button1.addActionListener { panel.background = Color.RED }
button2.addActionListener { panel.background = Color.GREEN }
button3.addActionListener { panel.background = Color.BLUE }
panel.add(button1)
panel.add(button2)
panel.add(button3)
frame.add(panel)
frame.pack()
panel

// Output1: 
<panel> will be rendered

// Cell2:
SWING(panel)

// Output2: 
<panel> will be rendered, similar to output1

// Cell3:
DISPLAY(SWING(panel))

// Output3: 
<panel> will be rendered, similar to output1, but multiple DISPLAY results can be sent.
```

**TODO:**
- [ ] Review the architecture for sending events this way. 
- [ ] Review the mimetype-definitions. Should we do it differently?
- [ ] Add better tests. Currently testing as been done by-hand.
- [ ] Should we bump the kernel version?

