### PR TITLE
Streamline embedded dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,23 @@ ktlint {
     }
 }
 
+// Dependencies shared between `implementation` and `embeddedKernel` configurations.
+// As we want strict control over dependencies for the embedded kernel, all of these
+// will be added with `transitive = false`, so all dependencies must be explicitly
+// listed here.
+val sharedEmbeddedDependencies = listOf(
+    libs.kotlin.dev.compilerEmbeddable,
+    libs.kotlin.dev.scriptingCompilerImplEmbeddable,
+    libs.kotlin.dev.scriptingCompilerEmbeddable,
+    libs.kotlin.dev.scriptingIdeServices,
+    libs.kotlin.dev.scriptingDependencies,
+    libs.kotlin.dev.scriptingDependenciesMavenAll,
+    // Dependency of `libs.kotlin.dev.compilerEmbeddable`
+    libs.jetbrains.trove4j,
+    // Embedded version of serialization plugin for notebook code
+    libs.serialization.dev.embeddedPlugin,
+)
+
 dependencies {
     // Dependency on module with compiler.
     api(projects.sharedCompiler)
@@ -43,16 +60,11 @@ dependencies {
     implementation(libs.coroutines.core)
 
     // Embedded compiler and scripting dependencies
-    implementation(libs.kotlin.dev.compilerEmbeddable)
-    implementation(libs.kotlin.dev.scriptingCompilerImplEmbeddable)
-    implementation(libs.kotlin.dev.scriptingCompilerEmbeddable)
-    implementation(libs.kotlin.dev.scriptingIdeServices)
-    implementation(libs.kotlin.dev.scriptingDependenciesMavenAll)
+    sharedEmbeddedDependencies.forEach {
+        implementation(it) { isTransitive = false }
+    }
     implementation(libs.kotlin.dev.scriptingCommon)
     implementation(libs.kotlin.dev.scriptingJvm)
-
-    // Embedded version of serialization plugin for notebook code
-    implementation(libs.serialization.dev.embeddedPlugin)
 
     // Logging
     implementation(libs.logging.slf4j.api)
@@ -95,18 +107,12 @@ dependencies {
     }
     scriptClasspathShadowed(libs.kotlin.dev.stdlib)
 
+    // Embedded kernel artifact
     embeddableKernel(projects.kotlinJupyterKernel) { isTransitive = false }
-    embeddableKernel(libs.kotlin.dev.scriptingDependencies) { isTransitive = false }
-    embeddableKernel(libs.kotlin.dev.scriptingDependenciesMavenAll) { isTransitive = false }
-    embeddableKernel(libs.kotlin.dev.scriptingIdeServices) { isTransitive = false }
-
-    embeddableKernel(libs.kotlin.dev.scriptingCompilerImplEmbeddable) { isTransitive = false }
-    embeddableKernel(libs.kotlin.dev.scriptingCompilerEmbeddable) { isTransitive = false }
-    embeddableKernel(libs.kotlin.dev.compilerEmbeddable) { isTransitive = false }
-
     embeddableKernel(libs.kotlin.dev.scriptRuntime) { isTransitive = false }
-
-    embeddableKernel(libs.serialization.dev.embeddedPlugin) { isTransitive = false }
+    sharedEmbeddedDependencies.forEach {
+        embeddableKernel(it) { isTransitive = false }
+    }
 }
 
 buildSettings {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ dependencies {
     // Dependency of `libs.kotlin.dev.compilerEmbeddable`
     implementation(libs.jetbrains.trove4j)
 
-
     // Logging
     implementation(libs.logging.slf4j.api)
     implementation(libs.logging.logback.classic)
@@ -81,7 +80,7 @@ dependencies {
 
     kernelShadowed(projects.kotlinJupyterKernel)
 
-    ideScriptClasspathShadowed (projects.lib) { isTransitive = false }
+    ideScriptClasspathShadowed(projects.lib) { isTransitive = false }
     ideScriptClasspathShadowed(projects.api) { isTransitive = false }
     ideScriptClasspathShadowed(projects.commonDependencies) {
         excludeStandardKotlinDependencies()
@@ -97,7 +96,7 @@ dependencies {
 
     // Embedded kernel artifact
     embeddableKernel(projects.kotlinJupyterKernel) { isTransitive = false }
-    embeddableKernel (libs.kotlin.dev.scriptRuntime) { isTransitive = false }
+    embeddableKernel(libs.kotlin.dev.scriptRuntime) { isTransitive = false }
     addSharedEmbeddedDependenciesTo(embeddableKernel)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,7 @@ jvmTarget = "11"
 springJvmTarget = "17"
 
 kotlin = "1.9.23"
-kotlinDependencies = "1.9.23"
-kotlinMavenResolver = "2.0.21"
+kotlinDependencies = "2.0.21"
 stableKotlin = "1.9.23"
 gradleKotlin = "1.9.23"
 kotlinDsl = "4.3.1"
@@ -29,6 +28,7 @@ logback = "1.5.3"
 http4k = "5.14.4.0"
 jupyterApi = "0.12.0-322"
 jetbrainsAnnotations = "24.1.0"
+trove4j = "1.0.20200330"
 
 junit = "5.10.2"
 kotlinTest = "5.8.1"
@@ -59,7 +59,7 @@ kotlin-dev-scriptingCompilerImplEmbeddable = { group = "org.jetbrains.kotlin", n
 kotlin-dev-scriptingCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-compiler-embeddable", version.ref = "kotlin" }
 kotlin-dev-scriptingIdeServices = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-ide-services", version.ref = "kotlin" }
 kotlin-dev-scriptingDependencies = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-dependencies", version.ref = "kotlinDependencies" }
-kotlin-dev-scriptingDependenciesMavenAll = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-dependencies-maven-all", version.ref = "kotlinMavenResolver" }
+kotlin-dev-scriptingDependenciesMavenAll = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-dependencies-maven-all", version.ref = "kotlinDependencies" }
 kotlin-dev-scriptingCommon = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-common", version.ref = "kotlin" }
 kotlin-dev-scriptingJvm = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-jvm", version.ref = "kotlin" }
 kotlin-dev-scriptRuntime = { group = "org.jetbrains.kotlin", name = "kotlin-script-runtime", version.ref = "kotlin" }
@@ -93,6 +93,7 @@ serialization-json5 = { group = "io.github.xn32", name = "json5k", version.ref =
 
 # JetBrains libraries
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations"}
+jetbrains-trove4j = { group = "org.jetbrains.intellij.deps", name="trove4j", version.ref = "trove4j" }
 
 # Coroutines
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
@@ -165,7 +166,7 @@ plugin-versionsUpdater = { module = "com.github.ben-manes:gradle-versions-plugin
 # Published artifacts of this project as binary dependencies
 jupyter-api = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-api", version.ref = "jupyterApi" }
 jupyter-apiAnnotations = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-api-annotations", version.ref = "jupyterApi" }
-jupyter-commonDependencies = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-common-dependencies", version.ref = "jupyterApi" }
+#jupyter-commonDependencies = { group = "org.jetbrains.kotlinx", name = "kotlin-jupyter-common-dependencies", version.ref = "jupyterApi" }
 
 [plugins]
 plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublishPlugin" }

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/LibraryResolver.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/LibraryResolver.kt
@@ -6,6 +6,9 @@ import org.jetbrains.kotlinx.jupyter.api.libraries.Variable
 
 /**
  * Interface for resolving libraries based on a given reference and arguments.
+ *
+ * Example:
+ * %use dataframe(0.10.0-dev-1373)
  */
 interface LibraryResolver {
     fun resolve(

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/EmbeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/EmbeddingTest.kt
@@ -153,10 +153,13 @@ class EmbedReplTest : AbstractSingleReplTest() {
 
     @Test
     fun testLibraryDescriptors() {
-        val result = eval("""
-            %use serialization
-            @Serializable class Test(val x: Int)
-        """.trimIndent())
+        val result =
+            eval(
+                """
+                %use serialization
+                @Serializable class Test(val x: Int)
+                """.trimIndent(),
+            )
         result.shouldBeInstanceOf<org.jetbrains.kotlinx.jupyter.repl.result.EvalResultEx.Success>()
     }
 }

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/EmbeddingTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/EmbeddingTest.kt
@@ -157,7 +157,7 @@ class EmbedReplTest : AbstractSingleReplTest() {
             %use serialization
             @Serializable class Test(val x: Int)
         """.trimIndent())
-        assertTrue(result is org.jetbrains.kotlinx.jupyter.repl.result.EvalResultEx.Success, "Is ${result.javaClass}")
+        result.shouldBeInstanceOf<org.jetbrains.kotlinx.jupyter.repl.result.EvalResultEx.Success>()
     }
 }
 

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/AbstractReplTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/AbstractReplTest.kt
@@ -129,20 +129,21 @@ abstract class AbstractReplTest {
                 httpUtil,
                 testLoggerFactory,
             )
-        val libraryResolver = getStandardResolver(
-            testLoggerFactory,
-            ".",
-            standardResolutionInfoProvider,
-            httpUtil.httpClient,
-            httpUtil.libraryDescriptorsManager,
-        )
+        val libraryResolver =
+            getStandardResolver(
+                testLoggerFactory,
+                ".",
+                standardResolutionInfoProvider,
+                httpUtil.httpClient,
+                httpUtil.libraryDescriptorsManager,
+            )
         return createRepl(
             httpUtil,
             scriptClasspath = embeddedClasspath,
             kernelRunMode = EmbeddedKernelRunMode,
             displayHandler = displayHandler,
             inMemoryReplResultsHolder = DefaultInMemoryReplResultsHolder(),
-            libraryResolver = libraryResolver
+            libraryResolver = libraryResolver,
         )
     }
 

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/AbstractReplTest.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/AbstractReplTest.kt
@@ -124,12 +124,25 @@ abstract class AbstractReplTest {
 
     protected fun makeEmbeddedRepl(displayHandler: DisplayHandler = NoOpDisplayHandler): ReplForJupyter {
         val embeddedClasspath: List<File> = System.getProperty("java.class.path").split(File.pathSeparator).map(::File)
+        val standardResolutionInfoProvider =
+            DefaultResolutionInfoProviderFactory.create(
+                httpUtil,
+                testLoggerFactory,
+            )
+        val libraryResolver = getStandardResolver(
+            testLoggerFactory,
+            ".",
+            standardResolutionInfoProvider,
+            httpUtil.httpClient,
+            httpUtil.libraryDescriptorsManager,
+        )
         return createRepl(
             httpUtil,
             scriptClasspath = embeddedClasspath,
             kernelRunMode = EmbeddedKernelRunMode,
             displayHandler = displayHandler,
             inMemoryReplResultsHolder = DefaultInMemoryReplResultsHolder(),
+            libraryResolver = libraryResolver
         )
     }
 


### PR DESCRIPTION
This PR ensures we load the same dependencies for the `implementation` and `embeddedKernel` configurations. Tests have also been added for the cases that prompted this change.