### PR TITLE
Descriptors in libraries.json

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -947,6 +947,25 @@ This is an advanced option that allows you to load additional dependencies or ad
 This can be particularly useful for libraries that cannot depend on the jupyter-api artifact but still want to modify
 the kernel behavior when loaded.
 
+For example:
+
+```json
+{
+    "definitions": [], 
+    "producers": [],
+    "descriptors": [
+      {
+        "dependencies": [
+          "my.library:my-library-jupyter-integration:1.0.0"
+        ],
+        "init": [
+          "DISPLAY(\"Implicitly loading Jupyter integration for MyLibrary...\")"
+        ]
+      }
+    ]
+}
+```
+
 For more information, see:
 
 * [Libraries repository](https://github.com/Kotlin/kotlin-jupyter-libraries)

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -933,12 +933,19 @@ resources. This file should contain FQNs of all integration classes in the JSON 
         {
             "fqn": "org.jetbrains.kotlinx.jupyter.example.GettingStartedIntegration"
         }
-    ]
+    ],
+    "descriptors": []
 }
 ```
 
 Classes derived from the `LibraryDefinition` interface should be added to the `definitions` array.
 Classes derived from the `LibraryDefinitionProducer` interface should be added to the `producers` array.
+
+Additionally, you're allowed to add full custom library descriptors to the `descriptors` array.
+This is an advanced option that allows you to load additional dependencies or add additional imports using the
+[library descriptor API](#creating-a-library-descriptor).
+This can be particularly useful for libraries that cannot depend on the jupyter-api artifact but still want to modify
+the kernel behavior when loaded.
 
 For more information, see:
 

--- a/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/Scanning.kt
+++ b/jupyter-lib/api/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/libraries/Scanning.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.jupyter.api.libraries
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 import org.jetbrains.kotlinx.jupyter.api.TypeName
 
 /**
@@ -48,9 +49,13 @@ data class LibrariesProducerDeclaration(
 /**
  * Serialized form of this class instance is a correct content of
  * [KOTLIN_JUPYTER_LIBRARIES_FILE_NAME] file, and vice versa.
+ *
+ * @param descriptors List of library descriptor JSON objects adhering to
+ *   `org.jetbrains.kotlinx.jupyter.libraries.LibraryDescriptor`.
  */
 @Serializable
 data class LibrariesScanResult(
     val definitions: List<LibrariesDefinitionDeclaration> = emptyList(),
     val producers: List<LibrariesProducerDeclaration> = emptyList(),
+    val descriptors: List<JsonObject> = emptyList(),
 )

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/ApiGradlePlugin.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/ApiGradlePlugin.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlinx.jupyter.api.plugin.tasks.JupyterApiResourcesTask
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.addMavenCentralIfDoesNotExist
-import org.jetbrains.kotlinx.jupyter.api.plugin.util.getBuildDirectory
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.whenAdded
 
 class ApiGradlePlugin : Plugin<Project> {
@@ -20,9 +19,6 @@ class ApiGradlePlugin : Plugin<Project> {
         with(target) {
             val pluginExtension = KotlinJupyterPluginExtension(target)
             extensions.add(KotlinJupyterPluginExtension.NAME, pluginExtension)
-
-            val jupyterBuildPath = getBuildDirectory().resolve(FQNS_PATH)
-            jupyterBuildPath.mkdirs()
             pluginExtension.addDependenciesIfNeeded()
 
             repositories {
@@ -63,8 +59,4 @@ class ApiGradlePlugin : Plugin<Project> {
                 }
             }
         }
-
-    companion object {
-        const val FQNS_PATH = "generated/jupyter/fqns"
-    }
 }

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.jupyter.api.plugin
 
 import org.gradle.api.Project
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.FQNAware
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.LibrariesScanResult
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.configureDependency
@@ -61,7 +62,7 @@ class KotlinJupyterPluginExtension(
         }
 
         @Suppress("unused")
-        fun descriptor(descriptor: String) {
+        fun descriptor(@Language("JSON") descriptor: String) {
             libraryDescriptors.add(descriptor)
         }
     }

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
@@ -15,11 +15,13 @@ class KotlinJupyterPluginExtension(
 
     private val libraryProducers: MutableSet<FQNAware> = mutableSetOf()
     private val libraryDefinitions: MutableSet<FQNAware> = mutableSetOf()
+    private val libraryDescriptors: MutableSet<String> = mutableSetOf()
 
     internal val libraryFqns get() =
         LibrariesScanResult(
             definitions = libraryDefinitions,
             producers = libraryProducers,
+            descriptors = libraryDescriptors,
         )
 
     internal fun addDependenciesIfNeeded() {
@@ -42,6 +44,7 @@ class KotlinJupyterPluginExtension(
     /**
      * Add adding library integrations by specifying their fully qualified names
      */
+    @Suppress("unused")
     fun integrations(action: IntegrationsSpec.() -> Unit) {
         IntegrationsSpec().apply(action)
     }
@@ -55,6 +58,11 @@ class KotlinJupyterPluginExtension(
         @Suppress("unused")
         fun definition(className: String) {
             libraryDefinitions.add(FQNAware(className))
+        }
+
+        @Suppress("unused")
+        fun descriptor(descriptor: String) {
+            libraryDescriptors.add(descriptor)
         }
     }
 

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/KotlinJupyterPluginExtension.kt
@@ -62,7 +62,9 @@ class KotlinJupyterPluginExtension(
         }
 
         @Suppress("unused")
-        fun descriptor(@Language("JSON") descriptor: String) {
+        fun descriptor(
+            @Language("JSON") descriptor: String,
+        ) {
             libraryDescriptors.add(descriptor)
         }
     }

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/tasks/JupyterApiResourcesTask.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/tasks/JupyterApiResourcesTask.kt
@@ -30,6 +30,13 @@ open class JupyterApiResourcesTask : DefaultTask() {
     @Input
     var libraryDefinitions: List<String> = emptyList()
 
+    /**
+     * List of JSON library descriptors in the
+     * [library descriptor format](https://github.com/Kotlin/kotlin-jupyter/blob/master/docs/libraries.md#creating-a-library-descriptor).
+     */
+    @Input
+    var libraryDescriptors: List<String> = emptyList()
+
     @OutputDirectory
     val outputDir: File = project.getBuildDirectory().resolve("jupyterProcessedResources")
 
@@ -42,6 +49,7 @@ open class JupyterApiResourcesTask : DefaultTask() {
             LibrariesScanResult(
                 definitions = libraryDefinitions.map { FQNAware(it) }.toSet(),
                 producers = libraryProducers.map { FQNAware(it) }.toSet(),
+                descriptors = libraryDescriptors.toSet(),
             )
 
         val resultObject =
@@ -70,14 +78,16 @@ open class JupyterApiResourcesTask : DefaultTask() {
         }
 
         return LibrariesScanResult(
-            fqns("definitions"),
-            fqns("producers"),
+            definitions = fqns("definitions"),
+            producers = fqns("producers"),
+            descriptors = emptySet(),
         )
     }
 
     operator fun LibrariesScanResult.plus(other: LibrariesScanResult): LibrariesScanResult =
         LibrariesScanResult(
-            definitions + other.definitions,
-            producers + other.producers,
+            definitions = definitions + other.definitions,
+            producers = producers + other.producers,
+            descriptors = descriptors + other.descriptors,
         )
 }

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/tasks/JupyterApiResourcesTask.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/tasks/JupyterApiResourcesTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.kotlinx.jupyter.api.plugin.ApiGradlePlugin
 import org.jetbrains.kotlinx.jupyter.api.plugin.KotlinJupyterPluginExtension
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.FQNAware
 import org.jetbrains.kotlinx.jupyter.api.plugin.util.LibrariesScanResult
@@ -52,36 +51,13 @@ open class JupyterApiResourcesTask : DefaultTask() {
                 descriptors = libraryDescriptors.toSet(),
             )
 
-        val resultObject =
-            jupyterExtensionScanResult +
-                taskScanResult +
-                getScanResultFromAnnotations()
+        val resultObject = jupyterExtensionScanResult + taskScanResult
         val json = Gson().toJson(resultObject)
 
         val jupyterDir = outputDir.resolve("META-INF/kotlin-jupyter-libraries")
         val libFile = jupyterDir.resolve("libraries.json")
         libFile.parentFile.mkdirs()
         libFile.writeText(json)
-    }
-
-    private fun getScanResultFromAnnotations(): LibrariesScanResult {
-        val path = project.getBuildDirectory().resolve(ApiGradlePlugin.FQNS_PATH)
-
-        fun fqns(name: String): Set<FQNAware> {
-            val file = path.resolve(name)
-            if (!file.exists()) return emptySet()
-            return file
-                .readLines()
-                .filter { it.isNotBlank() }
-                .map { FQNAware(it) }
-                .toSet()
-        }
-
-        return LibrariesScanResult(
-            definitions = fqns("definitions"),
-            producers = fqns("producers"),
-            descriptors = emptySet(),
-        )
     }
 
     operator fun LibrariesScanResult.plus(other: LibrariesScanResult): LibrariesScanResult =

--- a/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/util/LibrariesUtil.kt
+++ b/jupyter-lib/kotlin-jupyter-api-gradle-plugin/src/main/kotlin/org/jetbrains/kotlinx/jupyter/api/plugin/util/LibrariesUtil.kt
@@ -7,6 +7,7 @@ data class FQNAware(
 class LibrariesScanResult(
     val definitions: Set<FQNAware> = emptySet(),
     val producers: Set<FQNAware> = emptySet(),
+    val descriptors: Set<String> = emptySet(),
 )
 
 val emptyScanResult = LibrariesScanResult()

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/Parsing.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/Parsing.kt
@@ -2,14 +2,25 @@ package org.jetbrains.kotlinx.jupyter.libraries
 
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.jetbrains.kotlinx.jupyter.api.exceptions.ReplException
 import org.jetbrains.kotlinx.jupyter.protocol.api.KernelLoggerFactory
 
+private val jsonParser = Json { ignoreUnknownKeys = true }
+
 fun parseLibraryDescriptor(json: String): LibraryDescriptor =
     try {
-        Json.decodeFromString(json)
+        jsonParser.decodeFromString(json)
     } catch (e: SerializationException) {
         throw ReplException("Error during library deserialization. Library descriptor text:\n$json", e)
+    }
+
+fun parseLibraryDescriptor(jsonObject: JsonObject): LibraryDescriptor =
+    try {
+        jsonParser.decodeFromJsonElement(jsonObject)
+    } catch (e: SerializationException) {
+        throw ReplException("Error during library deserialization. Library descriptor text:\n$jsonObject", e)
     }
 
 fun parseLibraryDescriptors(

--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/Parsing.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/libraries/Parsing.kt
@@ -9,18 +9,24 @@ import org.jetbrains.kotlinx.jupyter.protocol.api.KernelLoggerFactory
 
 private val jsonParser = Json { ignoreUnknownKeys = true }
 
-fun parseLibraryDescriptor(json: String): LibraryDescriptor =
+private inline fun <T> parseCatching(
+    descriptor: T,
+    parse: (T) -> LibraryDescriptor,
+): LibraryDescriptor =
     try {
-        jsonParser.decodeFromString(json)
+        parse(descriptor)
     } catch (e: SerializationException) {
-        throw ReplException("Error during library deserialization. Library descriptor text:\n$json", e)
+        throw ReplException("Error during library deserialization. Library descriptor text:\n$descriptor", e)
+    }
+
+fun parseLibraryDescriptor(json: String): LibraryDescriptor =
+    parseCatching(json) {
+        jsonParser.decodeFromString(it)
     }
 
 fun parseLibraryDescriptor(jsonObject: JsonObject): LibraryDescriptor =
-    try {
-        jsonParser.decodeFromJsonElement(jsonObject)
-    } catch (e: SerializationException) {
-        throw ReplException("Error during library deserialization. Library descriptor text:\n$jsonObject", e)
+    parseCatching(jsonObject) {
+        jsonParser.decodeFromJsonElement(it)
     }
 
 fun parseLibraryDescriptors(

--- a/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/CustomLibraryResolverTests.kt
+++ b/src/test/kotlin/org/jetbrains/kotlinx/jupyter/test/repl/CustomLibraryResolverTests.kt
@@ -386,36 +386,6 @@ class CustomLibraryResolverTests : AbstractReplTest() {
     }
 
     @Test
-    fun testIncorrectDescriptors() {
-        val ex1 =
-            assertThrows<ReplException> {
-                parseLibraryDescriptor(
-                    """
-                    {
-                        "imports": []
-                    """.trimIndent(),
-                )
-            }
-        assertTrue(ex1.cause is SerializationException)
-
-        val ex2 =
-            assertThrows<ReplException> {
-                parseLibraryDescriptor(
-                    """
-                    {
-                        "imports2": []
-                    }
-                    """.trimIndent(),
-                )
-            }
-        assertTrue(ex2.cause is SerializationException)
-
-        assertDoesNotThrow {
-            parseLibraryDescriptor("{}")
-        }
-    }
-
-    @Test
     fun testLibraryWithResourcesDescriptorParsing() {
         val descriptor = parseLibraryDescriptor(File("src/test/testData/lib-with-resources.json").readText())
         val resources = descriptor.resources


### PR DESCRIPTION
Relates to https://github.com/Kotlin/dataframe/issues/1140

Adds the ability to have full JSON library descriptors inside the libraries.json instead of just fqn's to integration classes.

This will be [used in DataFrame](https://github.com/Kotlin/dataframe/pull/1415) to load the `dataframe-jupyter` artifact when `dataframe-core` is present without it (which is common when using your project as dependency to the notebook).