### PR TITLE
Quality: Compiler args list grows unbounded on repeated `@CompilerArgs` processing

### DIFF
--- a/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/compiler/DefaultCompilerArgsConfigurator.kt
+++ b/jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/compiler/DefaultCompilerArgsConfigurator.kt
@@ -35,7 +35,13 @@ class DefaultCompilerArgsConfigurator(
     ): ResultWithDiagnostics<ScriptCompilationConfiguration> {
         annotations.forEach {
             when (it) {
-                is CompilerArgs -> argsList.addAll(it.values)
+                is CompilerArgs -> {
+                    it.values.forEach { arg ->
+                        if (arg !in argsList) {
+                            argsList.add(arg)
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Hi there! 👋

While exploring the codebase, I noticed a minor opportunity for improvement in `jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/compiler/DefaultCompilerArgsConfigurator.kt`.

**Context:**
`configure()` appends annotation-provided args into a mutable list every time a cell is processed. Re-running the same annotated cell repeatedly keeps duplicating arguments indefinitely, which can eventually produce very long compiler command lines, slower compilation, and potential compilation failures due to conflicting/repeated options.


**Proposed fix:**
De-duplicate appended args (or store them in a set-like structure while preserving order), for example:

private val argsList = mutableListOf(/* defaults */)

override fun configure(
    configuration: ScriptCompilationConfiguration,
    annotations: List<Annotation>,
): ResultWithDiagnostics<ScriptCompilationConfiguration> {
    annotations.filterIsInstance<CompilerArgs>()
        .flatMap { it.values.asList() }
        .forEach { arg ->
            if (arg !in argsList) argsList.add(arg)
        }
    return configuration.asSuccess()
}

If ordered option pairs must be preserved, de-duplicate by full option tuple rather than single token.

**Files changed:**
- `jupyter-lib/shared-compiler/src/main/kotlin/org/jetbrains/kotlinx/jupyter/compiler/DefaultCompilerArgsConfigurator.kt` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

——
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com


Closes #503